### PR TITLE
CCUI-2667-LayoutBoxStylesFixes

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
@@ -34,9 +34,13 @@ import ViewComfyIcon from '@mui/icons-material/ViewComfy';
 
 import type { BlockContent } from 'mdast';
 import { ContainerDirective } from 'mdast-util-directive';
-import { fromMarkdown } from 'mdast-util-from-markdown';
 import { Options as ToMarkdownOptions } from 'mdast-util-to-markdown';
-import { exportMarkdownFromLexical, defaultToMarkdownExtensions, placeCaretInsideDirective } from '@rapid-cmi5/ui';
+import {
+  convertMarkdownToMdast,
+  exportMarkdownFromLexical,
+  defaultToMarkdownExtensions,
+  placeCaretInsideDirective,
+} from '@rapid-cmi5/ui';
 
 const DEFAULT_MARKDOWN_OPTIONS: ToMarkdownOptions = {
   listItemIndent: 'one',
@@ -121,10 +125,10 @@ export const InsertLayoutBox = () => {
         theMarkDown = 'Layout Box';
       }
 
-      const theChildMDast = fromMarkdown(theMarkDown, {
-        extensions: syntaxExtensions,
-        mdastExtensions: null,
-      });
+      const theChildMDast = convertMarkdownToMdast(
+        theMarkDown,
+        syntaxExtensions,
+      );
 
       const mdast: ContainerDirective = {
         type: 'containerDirective',

--- a/packages/ui/src/lib/cmi5/mdx/editors/AdmonitionEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/editors/AdmonitionEditor.tsx
@@ -38,7 +38,6 @@ import {
 
 import ExpandCircleDownIcon from '@mui/icons-material/ExpandCircleDown';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { fromMarkdown, type Options } from 'mdast-util-from-markdown';
 import { toMarkdown } from 'mdast-util-to-markdown';
 
 import {
@@ -57,6 +56,7 @@ import { AdmonitionTypeEnum } from '@rapid-cmi5/cmi5-build-common';
 import { SelectorMainUi } from '../../../inputs/selectors/selectors';
 import { debugLogError } from '../../../utility/logger';
 import { editorInPlayback$ } from '../state/vars';
+import { convertMarkdownToMdast } from '../util/conversion';
 
 export declare interface AdmonitionDirectiveEditorProps<
   T extends Directives = Directives,
@@ -359,10 +359,10 @@ export const AdmonitionEditor: React.FC<DirectiveEditorProps> = ({
           >
             <NestedLexicalEditor<Paragraph>
               getContent={(node) => {
-                const theNode = fromMarkdown(getTitle(mdastNode.attributes), {
-                  extensions: syntaxExtensions,
-                  mdastExtensions: null,
-                });
+                const theNode = convertMarkdownToMdast(
+                  getTitle(mdastNode.attributes),
+                  syntaxExtensions,
+                );
                 return theNode.children;
               }}
               getUpdatedMdastNode={(

--- a/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
@@ -8,7 +8,6 @@ import {
 import type { ContainerDirective } from 'mdast-util-directive';
 
 import { Paragraph } from 'mdast';
-import { fromMarkdown, type Options } from 'mdast-util-from-markdown';
 import { toMarkdown } from 'mdast-util-to-markdown';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -41,6 +40,7 @@ import { ButtonIcon } from '../../../../utility/buttons';
 import { debugLog } from '../../../../utility/logger';
 import { editorInPlayback$ } from '../../state/vars';
 import { dividerColor } from '@rapid-cmi5/ui';
+import { convertMarkdownToMdast } from '../../util/conversion';
 
 /**
  * Accordion Editor for accordion directives
@@ -285,10 +285,10 @@ export const ImageLabelEditor: React.FC<
                 <Box sx={{ padding: 2 }}>
                   <NestedLexicalEditor<Paragraph>
                     getContent={(node) => {
-                      const theNode = fromMarkdown(theTitle, {
-                        extensions: syntaxExtensions,
-                        mdastExtensions: null,
-                      });
+                      const theNode = convertMarkdownToMdast(
+                        theTitle,
+                        syntaxExtensions,
+                      );
                       return theNode.children;
                     }}
                     getUpdatedMdastNode={(

--- a/packages/ui/src/lib/cmi5/mdx/util/conversion.ts
+++ b/packages/ui/src/lib/cmi5/mdx/util/conversion.ts
@@ -21,6 +21,7 @@ import {
   gfmTaskListItemToMarkdown,
 } from 'mdast-util-gfm-task-list-item';
 import { gfmTableFromMarkdown, gfmTableToMarkdown } from 'mdast-util-gfm-table';
+import { gfmStrikethrough } from 'micromark-extension-gfm-strikethrough';
 import { Options, Value, fromMarkdown } from 'mdast-util-from-markdown';
 import { Extension } from 'micromark-util-types';
 
@@ -54,7 +55,8 @@ export const convertMarkdownToMdast = (
   syntaxExtensions: Extension[],
 ) => {
   const theChildMDast = fromMarkdown(theMarkDown, {
-    extensions: syntaxExtensions,
+    // Ensure ~~strikethrough~~ tokens are parsed as GFM delete nodes.
+    extensions: [...syntaxExtensions, gfmStrikethrough()],
     mdastExtensions: [
       mdxJsxFromMarkdown(),
       directiveFromMarkdown(),


### PR DESCRIPTION
• Fix Layoutbox issues with strikethrough and underline not keeping formatting when going from paragraph to contained content

• Use shared convertMarkdownToMdast helper so style nodes are preserved.

• Update AdmonitionEditor and ImageLabelEditor to prevent similar style loss