### PR TITLE
Cc UI 2737 move style button to image context menu

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/image/EditImageToolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/image/EditImageToolbar.tsx
@@ -25,7 +25,8 @@ import { clickPosition$, isLabelDropping$ } from '@rapid-cmi5/ui';
 
 
 //MB
-import { imageStyleDialogOpen$ } from './index';
+//import { imageStyleDialogOpen$ } from './index';
+import { StyleDialog } from './StyleDialog';
 
 export interface EditImageToolbarProps {
   nodeKey: string;
@@ -64,12 +65,17 @@ export function EditImageToolbar({
     useCellValues(readOnly$);
   const [editor] = useLexicalComposerContext();
   const openEditImageDialog = usePublisher(openEditImageDialog$);
-  const openStyleDialog = usePublisher(imageStyleDialogOpen$); //MB
+  //const openStyleDialog = usePublisher(imageStyleDialogOpen$); //MB
 
   const [isMarking, setIsMarking] = useState(false);
   const muiTheme = useTheme();
 
   const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  //For letting style dialogue work outside imagedialog.
+const [imageStyle, setImageStyle] = useState<string>('');
+const [isStyleDialogOpen, setIsStyleDialogOpen] = useState(false);
+
 
   /**
    * Set marker position to follow mouse
@@ -110,7 +116,11 @@ export function EditImageToolbar({
     }
   });
 
+  
   return (
+    
+    // Wrap this in a fragment so styledialog can liv eOUTSIDE of imageDialogue without us having to rewire it compltely. 
+    <>
     <Stack
       direction="row"
       spacing={0}
@@ -148,9 +158,12 @@ export function EditImageToolbar({
       <IconButton
         aria-label="edit styles"
         disabled={readOnly}
-        onClick={() => openStyleDialog(true)}
+        onClick={() => {
+          setIsStyleDialogOpen(true)
+          console.log('Button was clicked!')}}
       >
         {/* MB */}
+              
         <PaletteIcon /> 
       </IconButton>
  
@@ -190,5 +203,14 @@ export function EditImageToolbar({
         <DeleteForeverIcon />
       </IconButton>
     </Stack>
+
+    {/* Dialog lives OUTSIDE the button, but inside the component */}
+    <StyleDialog
+      isOpen={isStyleDialogOpen}
+      style={imageStyle}
+      setImageStyle={setImageStyle}
+      setIsStyleDialogOpen={setIsStyleDialogOpen}
+    />
+  </>
   );
 }

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/image/ImageDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/image/ImageDialog.tsx
@@ -57,7 +57,7 @@ export const ImageDialog: React.FC = () => {
   const [title, setTitle] = useState<string>('');
   const [linkUrl, setLinkUrl] = useState<string>('');
   const [imageStyle, setImageStyle] = useState<string>('');
-  const [isStyleDialogOpen, setIsStyleDialogOpen] = useState(false);
+  //const [isStyleDialogOpen, setIsStyleDialogOpen] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<FileList | null>(null);
   const [fileOptions, setFileOptions] = useState<string[]>([]);
   const [width, setWidth] = useState<string>('');
@@ -367,7 +367,7 @@ export const ImageDialog: React.FC = () => {
                   name="edit-style"
                   props={{
                     onClick: (event) => {
-                      setIsStyleDialogOpen(true);
+                     // setIsStyleDialogOpen(true);
                     },
                   }}
                 >
@@ -392,7 +392,7 @@ export const ImageDialog: React.FC = () => {
                   value={imageStyle}
                   onChange={(textValue: string) => setImageStyle(textValue)}
                   onClick={() => {
-                    setIsStyleDialogOpen(true);
+                    //setIsStyleDialogOpen(true);
                   }}
                   infoText="Inline styles Ex. opacity:0.5;"
                   slotProps={{
@@ -407,12 +407,12 @@ export const ImageDialog: React.FC = () => {
           {/*</DialogContent>*/}
         </>
       </ModalDialog>
-      <StyleDialog
+      {/* MBStyleDialog
         isOpen={isStyleDialogOpen}
         style={imageStyle}
         setImageStyle={setImageStyle}
         setIsStyleDialogOpen={setIsStyleDialogOpen}
-      />
+      />*/}
     </>
   );
 };

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/image/index.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/image/index.ts
@@ -118,8 +118,33 @@ export interface SaveImageParameters extends BaseImageParameters {
 
 
 // New signals for moving style popup window -MB
-export const imageStyleDialogOpen$ = Cell(false);
+// oldexport const imageStyleDialogOpen$ = Cell(false);
+const StyleCell$ = Cell(
+  // initial value
+  false, //We want it hidden
+  // the r is the realm instance that starts the cell
+  (r) => {
+    r.sub(StyleCell$, (value) => {
+      console.log('StyleCell$ changed to', value)
+    })
+  },
+  // distinct flag, true by default
+  true
+)
 
+// Since signals have no initial value, you need to specify the type of data that will flow through them
+const StyleSignal$ = Signal<boolean>(
+  // the r is the realm instance that starts the cell
+  (r) => {
+    r.sub(StyleSignal$, (value) => {
+      console.log('StyleSignal$ changed to', value)
+    })
+    // publishing a value through a signal will publish it into $StyleCell as well
+    r.link(StyleSignal$, StyleCell$)
+  },
+  // distinct flag
+  true
+)
 
 
 /**


### PR DESCRIPTION
Because of the current wiring, using a Signal was working in triggering the state, but because the host of the render StyleDialogue was ImageDialog this was causing the state to change, but for it to only show when ImageDialog was also open. I moved it to 'live' in the edit image toolbar for now. Further rewiring to make it a stand alone component can be considered for the future. 