### PR TITLE
Cc UI 2763 fullscreen img

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageNode.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageNode.tsx
@@ -14,6 +14,9 @@ import { DecoratorNode } from 'lexical';
 import { ImageViewer } from './ImageViewer';
 import { MdxJsxAttribute, MdxJsxExpressionAttribute } from 'mdast-util-mdx-jsx';
 
+import { useTimeStampUUID } from '@rapid-cmi5/ui';
+const { generateId } = useTimeStampUUID();
+
 function convertImageElement(domNode: Node): null | DOMConversionOutput {
   if (domNode instanceof HTMLImageElement) {
     const { alt: altText, id, src, title, width, height } = domNode;
@@ -149,7 +152,6 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     key?: NodeKey,
     id?: string,
   ) {
-
     super(key);
     this.__src = src;
     this.__title = title;
@@ -158,7 +160,7 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     this.__height = height ? height : 'inherit';
     this.__rest = rest ?? [];
     this.__href = href;
-    this.__id = id;
+    this.__id = id ?? generateId();
   }
 
   /** @internal */

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/image/ImageNode.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/image/ImageNode.tsx
@@ -14,14 +14,9 @@ import { DecoratorNode } from 'lexical';
 import { ImageEditor } from './ImageEditor';
 import { MdxJsxAttribute, MdxJsxExpressionAttribute } from 'mdast-util-mdx-jsx';
 
-/**
- * Creates a random ID for each created image. This allows them to be referencable later.
- *
- * @returns - A random string of numbers to be used in ID for image
- */
-function generateImageId() {
-  return `image-${crypto.randomUUID()}`;
-}
+import { useTimeStampUUID } from '@rapid-cmi5/ui';
+
+const { generateId } = useTimeStampUUID();
 
 function convertImageElement(domNode: Node): null | DOMConversionOutput {
   if (domNode instanceof HTMLImageElement) {
@@ -166,7 +161,7 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     this.__height = height ? height : 'inherit';
     this.__rest = rest ?? [];
     this.__href = href;
-    this.__id = id ?? generateImageId();
+    this.__id = id ?? generateId();
   }
 
   /** @internal */


### PR DESCRIPTION
To test if the image was being hidden and not clicked I added “  console.log('Clicked element:', event.target); 
Then when clicking on element got this:
Clicked element: <div id="image-labels-undefined" style="position: absolute; left: 0px; width: 100%; height: 100%;"></div>
logger.ts:130 log => clicked imageId undefined

So it was registering the click. Interestingly enough, images WITH labels and text boxs had IDs and went fullscreen.

The logic runs on there being an image id, when adding a label or text overlay those have ids and GAVE them to their parent image. But the image itself does not appear to have it's own ID. I went back to ImageNode and made a 'generate id' function and added it to creation. If an image has an id, nothing happens, if it doesn't it is given one. Now all images open fullscreen. 

https://github.com/user-attachments/assets/899ec46d-3be5-4f72-a0cc-ddadb5aae117


