### PR TITLE
adjusted script, added .env and filled in readme

### DIFF
--- a/apps/cc-cmi5-player/README.md
+++ b/apps/cc-cmi5-player/README.md
@@ -41,6 +41,46 @@ Certain env vars can be overridden by editing cfg.json
 In order to test locally, you need a cmi5 course to be present in your published build directory.<br/>
 As a one time set up, copy the placeholder files into the nx project. Note - this directory is ignored by git.
 
+#### Running local tests to send statements
+
+Running locally, the player is not automatically connected to an LRS. To test statement sending or flow, there is a script that enables it to communicate with the LRS at adlnet.gov, those username and password are needed separately for that service.
+
+The script to run your hosted content can be found in the root of the repo ie rapidcmi5/scripts/launchCmi5AsTest.ps1.
+
+To connect to the player there is a secret bearer token. This is not to be shared. In the ./scripts folder is an example.env file, use that to make a .env and place your secret token.
+
+Then make sure you are in the root folder and run
+
+```
+launchCmi5AsTest.ps1 "Your username"
+```
+
+If you forget to enter a username you will be prompted, this is the name that will be used as the actor in the statements.
+
+You will receive a URL in the commandline similar to
+
+```
+http://localhost:4200/content/1/1604/compiled_course/blocks/dave-course/introduction/index.html?endpoint=https%3A%2F%2Fcpt-player.develop-cp.rangeos.engineering%2Flrs&fetch=https%3A%2F%2Fcpt....etc
+
+```
+
+The next step is to take everything, starting at the ?, after index.html. Copy it, then paste it at the end of your local hosted version of the player in your URL bar.
+`http://localhost:4200/content/1/1604/.../index.html` -> Highlight and copy everything after this.
+
+So if you are hosting on
+
+```
+http://localhost:4300
+```
+
+it would become
+
+```
+http:localhost:4300?endpoint=https%3A%2F%2Fcpt-player.develop-cp.rangeos.engineering%2Flrs&fetch=https%3A%2F%2Fcpt....etc
+```
+
+That will allow you to see statements work in realtime.
+
 ##### Destination Path
 
 /libs/ui/components/branded/src/assets/cmi5-player/

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,3 @@
+
+#If needed to test cmi5 player with launch script
+#BEARER_TOKEN="Some secret token"

--- a/scripts/launchCmi5playerTest.ps1
+++ b/scripts/launchCmi5playerTest.ps1
@@ -1,0 +1,59 @@
+# User can add name as param when running script
+param(
+    [string]$Name
+)
+
+if (-not $Name) {
+    $Name = Read-Host "Enter actor name"
+    $Name = $Name.Trim()  # remove extra spaces at start/end
+}
+# Load the secret token from .env
+$envFile = Join-Path $PSScriptRoot ".env"
+if (Test-Path $envFile) {
+    Get-Content $envFile | ForEach-Object {
+        $_ = $_.Trim()
+        if ($_ -and $_ -notmatch "^#") {
+            $parts = $_ -split "=", 2
+            if ($parts.Count -eq 2) {
+                [System.Environment]::SetEnvironmentVariable($parts[0].Trim(), $parts[1].Trim())
+            }
+        }
+    }
+}
+
+# Get the token safely
+$token = $env:BEARER_TOKEN.Trim()
+
+# Registration number must always be different, because to the player these are different sessions and cannot repeat.
+# This is the form of a registration number as string - "713eb82a-bca1-26ab-d1dc-abb20965c24b
+$reg = [guid]::NewGuid().ToString()
+
+$body = @{
+  actor = @{
+    objectType = "Agent"
+    account = @{
+      homePage = "https://moodle.com"
+      name     = $Name
+    }
+  }
+
+  reg = $reg
+  
+  returnUrl = "https://lms.example.com/return"
+} | ConvertTo-Json -Depth 5
+
+$response = Invoke-RestMethod `
+  -Method POST `
+  -Uri "https://cpt-player.develop-cp.rangeos.engineering/api/v1/course/1604/launch-url/0" `
+  -Headers @{
+    Authorization = "Bearer $token"
+    "Content-Type" = "application/json"
+  } `
+  -Body $body
+
+# Extract query string from returned URL and rewrite host
+$uri = [System.Uri]$response.url
+$localUrl = "http://localhost:4200$($uri.PathAndQuery)"
+
+Write-Output $localUrl
+


### PR DESCRIPTION
This is a script written by Aaron that allows the use of the cmi5 player locally with a live LRS. It's good to see statements, make sure AUs work, etc. I tweaked it to make it easy to use, generate it's own reg id (no sessions can have the same), and have the token hidden in the .env. I also added Readme doc for user use. 