### PR TITLE
CCUI-2380 #comment Moved playback to the view mode radio button group

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/RapidCmi5Toolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/RapidCmi5Toolbar.tsx
@@ -40,6 +40,7 @@ import {
   dividerColor,
   toolbarRect$,
   maxSlideWidth$,
+  debugLog,
 } from '@rapid-cmi5/ui';
 
 import { displayData } from '../../../redux/courseBuilderReducer';
@@ -139,7 +140,7 @@ export const RapidCmi5Toolbar: React.FC = () => {
   }, [content]);
 
   useEffect(() => {
-    console.log('viewmode', viewmode);
+    debugLog('viewmode', viewmode);
   }, [viewmode]);
 
   /**
@@ -224,7 +225,7 @@ export const RapidCmi5Toolbar: React.FC = () => {
         }}
       >
         <Stack direction="column" spacing={1} sx={{ padding: 1 }}>
-          {viewmode === 'rich-text' && (
+          {viewmode === 'rich-text' && !isPlayback && (
             <Stack direction="row" spacing={1}>
               <Stack direction="row" spacing={0} sx={{ flexGrow: 1 }}>
                 <BoldItalicUnderlineToggles />
@@ -316,7 +317,10 @@ export const RapidCmi5Toolbar: React.FC = () => {
               </Stack>
             </Stack>
           )}
-          {viewmode !== 'rich-text' && <Box sx={{ minHeight: '32px' }}></Box>}
+          {(viewmode === 'source' ||
+            (viewmode === 'rich-text' && isPlayback)) && (
+            <Box sx={{ minHeight: '32px' }}></Box>
+          )}
           <Stack
             direction="row"
             spacing={1}
@@ -367,43 +371,6 @@ export const RapidCmi5Toolbar: React.FC = () => {
                 maxHeight: '32px',
               }}
             >
-              <MUIButtonWithTooltip
-                title={isPlayback ? 'Preview OFF' : 'Preview ON'}
-                onClick={() => {
-                  changeViewMode('rich-text');
-                  realm.pub(editorInPlayback$, !isPlayback);
-                  realm.pub(editorInPlayback$, !isPlayback);
-                }}
-                disabled={viewMode === 'source'}
-              >
-                {isPlayback ? (
-                  <StopScreenShareIcon
-                    sx={{
-                      color:
-                        viewmode === 'source'
-                          ? disabledIconColor
-                          : activeIconColor,
-                      fill:
-                        viewmode === 'source'
-                          ? disabledIconColor
-                          : activeIconColor,
-                    }}
-                  />
-                ) : (
-                  <ScreenShareIcon
-                    sx={{
-                      color:
-                        viewmode === 'source'
-                          ? disabledIconColor
-                          : activeIconColor,
-                      fill:
-                        viewmode === 'source'
-                          ? disabledIconColor
-                          : activeIconColor,
-                    }}
-                  />
-                )}
-              </MUIButtonWithTooltip>
               <Stack
                 direction="row"
                 sx={{
@@ -420,18 +387,46 @@ export const RapidCmi5Toolbar: React.FC = () => {
                   title={t('toolbar.richText', 'Edit Rich Text')}
                   onClick={() => {
                     changeViewMode('rich-text');
+                    realm.pub(editorInPlayback$, false);
                   }}
-                  disabled={viewMode === 'rich-text'}
+                  disabled={viewMode === 'rich-text' && !isPlayback}
                 >
                   <ArtTrackIcon
                     sx={{
                       fontSize: '32px',
                       color:
-                        viewmode === 'rich-text'
+                        viewMode === 'rich-text' && !isPlayback
                           ? disabledIconColor
                           : activeIconColor,
                       fill:
-                        viewmode === 'rich-text'
+                        viewMode === 'rich-text' && !isPlayback
+                          ? disabledIconColor
+                          : activeIconColor,
+                    }}
+                  />
+                </MUIButtonWithTooltip>
+                <Divider
+                  orientation="vertical"
+                  color="divider"
+                  flexItem
+                  sx={{ mx: 0 }}
+                />
+                <MUIButtonWithTooltip
+                  title="Preview"
+                  onClick={() => {
+                    changeViewMode('rich-text');
+                    realm.pub(editorInPlayback$, true);
+                  }}
+                  disabled={viewMode === 'rich-text' && isPlayback}
+                >
+                  <ScreenShareIcon
+                    sx={{
+                      color:
+                        viewMode === 'rich-text' && isPlayback
+                          ? disabledIconColor
+                          : activeIconColor,
+                      fill:
+                        viewMode === 'rich-text' && isPlayback
                           ? disabledIconColor
                           : activeIconColor,
                     }}
@@ -453,61 +448,9 @@ export const RapidCmi5Toolbar: React.FC = () => {
                   {markDownIcon}
                 </MUIButtonWithTooltip>
               </Stack>
-
-              {/* <Stack
-                direction="row"
-                sx={{
-                  borderRadius: 4,
-                  paddingLeft: 0.5,
-                  paddingRight: 0.5,
-                  height: '32px',
-                  border: `1px solid ${disabledIconColor}`,
-                  transition:
-                    'transform 120ms ease, background-color 120ms ease',
-                }}
-              >
-                <MUIButtonWithTooltip
-                  title={t('toolbar.richText', 'Edit Rich Text')}
-                  onClick={() => {
-                    changeViewMode('rich-text');
-                  }}
-                  disabled={viewMode === 'rich-text'}
-                >
-                  <ArtTrackIcon
-                    sx={{
-                      fontSize: '32px',
-                      color:
-                        viewmode === 'rich-text'
-                          ? disabledIconColor
-                          : activeIconColor,
-                      fill:
-                        viewmode === 'rich-text'
-                          ? disabledIconColor
-                          : activeIconColor,
-                    }}
-                  />
-                </MUIButtonWithTooltip>
-                <Divider
-                  orientation="vertical"
-                  color="divider"
-                  flexItem
-                  sx={{ mx: 0 }}
-                />
-                <MUIButtonWithTooltip
-                  title="Edit Markdown"
-                  onClick={() => {
-                    changeViewMode('source');
-                  }}
-                  disabled={viewMode === 'source'}
-                >
-                  {markDownIcon}
-                </MUIButtonWithTooltip>
-              </Stack> */}
             </Stack>
           </Stack>
         </Stack>
-
-        {viewmode === 'source' && <></>}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Moved playback to the view mode radio button group in order to make it clearer when you are in preview mode and not able to edit. Also, hiding the toolbar in playback mode to avoid errors.

<img width="192" height="52" alt="Screenshot 2026-03-27 at 9 00 58 AM" src="https://github.com/user-attachments/assets/3de84c4a-e7cf-41a6-8fd0-88d5b3662c41" />

