### PR TITLE
CCUI-2889 #comment Fixes image not respecting right margin.

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/player/rc5-styles.css
+++ b/apps/cc-cmi5-player/src/app/components/player/rc5-styles.css
@@ -100,7 +100,14 @@
   z-index: 9999;
 }
 
-.imageWrapper img {
+.imageWrapper,
+[data-editor-block-type='image'] {
+  display: inline-block;
+  position: relative;
+}
+
+.imageWrapper img,
+[data-editor-block-type='image'] img {
   max-width: 100%;
   max-height: 100%;
 }


### PR DESCRIPTION
Images were not respecting auto margins imposed by lesson content width in the cmi5 player. This caused images to display differently between the editor and the player.