### PR TITLE
CCUI-2904 #comment Set min width on lit buttons so they don't wrap

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/ListsToggle.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/ListsToggle.tsx
@@ -1,13 +1,18 @@
-import React from 'react'
-import { useCellValues, usePublisher } from '@mdxeditor/gurx'
-import { applyListType$, currentListType$, iconComponentFor$, useTranslation } from '@mdxeditor/editor'
-import { MUISingleChoiceToggleGroup } from './MUISingleChoiceToggleGroup'
+import React from 'react';
+import { useCellValues, usePublisher } from '@mdxeditor/gurx';
+import {
+  applyListType$,
+  currentListType$,
+  iconComponentFor$,
+  useTranslation,
+} from '@mdxeditor/editor';
+import { MUISingleChoiceToggleGroup } from './MUISingleChoiceToggleGroup';
 
 const ICON_NAME_MAP = {
   bullet: 'format_list_bulleted',
   number: 'format_list_numbered',
-  check: 'format_list_checked'
-} as const
+  check: 'format_list_checked',
+} as const;
 
 /**
  * A toolbar toggle that allows the user to toggle between bulleted, numbered, and check lists.
@@ -16,22 +21,34 @@ const ICON_NAME_MAP = {
  * @group Toolbar Components
  * @param options - The list types that the user can toggle between. Defaults to `['bullet', 'number', 'check']`.
  */
-export const ListsToggle: React.FC<{ options?: ('bullet' | 'number' | 'check')[] }> = ({ options = ['bullet', 'number', 'check'] }) => {
-  const [currentListType, iconComponentFor] = useCellValues(currentListType$, iconComponentFor$)
-  const applyListType = usePublisher(applyListType$)
-  const t = useTranslation()
+export const ListsToggle: React.FC<{
+  options?: ('bullet' | 'number' | 'check')[];
+}> = ({ options = ['bullet', 'number', 'check'] }) => {
+  const [currentListType, iconComponentFor] = useCellValues(
+    currentListType$,
+    iconComponentFor$,
+  );
+  const applyListType = usePublisher(applyListType$);
+  const t = useTranslation();
 
   const LIST_TITLE_MAP = {
     bullet: t('toolbar.bulletedList', 'Bulleted List'),
     number: t('toolbar.numberedList', 'Numbered List'),
-    check: t('toolbar.checkList', 'Check List')
-  } as const
+    check: t('toolbar.checkList', 'Check List'),
+  } as const;
 
   const items = options.map((type) => ({
     value: type,
     title: LIST_TITLE_MAP[type],
-    contents: iconComponentFor(ICON_NAME_MAP[type])
-  }))
+    contents: iconComponentFor(ICON_NAME_MAP[type]),
+  }));
 
-  return <MUISingleChoiceToggleGroup value={currentListType || ''} items={items} onChange={applyListType} />
-}
+  return (
+    <MUISingleChoiceToggleGroup
+      sxProps={{ minWidth: '100px' }}
+      value={currentListType || ''}
+      items={items}
+      onChange={applyListType}
+    />
+  );
+};

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/MUISingleChoiceToggleGroup.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/MUISingleChoiceToggleGroup.tsx
@@ -1,5 +1,11 @@
-
-import { alpha, IconButton, Tooltip, useTheme } from '@mui/material';
+import {
+  alpha,
+  Box,
+  IconButton,
+  SxProps,
+  Tooltip,
+  useTheme,
+} from '@mui/material';
 import { tooltipStyle } from '../../styles/styles';
 
 /**
@@ -10,6 +16,7 @@ export const MUISingleChoiceToggleGroup = <T extends string>({
   value,
   onChange,
   items,
+  sxProps,
 }: {
   items: {
     title: string;
@@ -18,10 +25,11 @@ export const MUISingleChoiceToggleGroup = <T extends string>({
   }[];
   onChange: (value: T | '') => void;
   value: T | '';
+  sxProps?: SxProps;
 }) => {
   const theme = useTheme();
   return (
-    <div>
+    <Box sx={sxProps}>
       {items.map((item, index) => {
         const on = item.value === value;
         return (
@@ -37,13 +45,13 @@ export const MUISingleChoiceToggleGroup = <T extends string>({
                 },
               }}
               size={'small'}
-              onClick={() => onChange(on ? '': item.value)}
+              onClick={() => onChange(on ? '' : item.value)}
             >
               {item.contents}
             </IconButton>
           </Tooltip>
         );
       })}
-    </div>
+    </Box>
   );
 };


### PR DESCRIPTION
Fixes an issue where the lit buttons wrap at odd screen dimensions. I believe this may be a bug in the Radix library so this is more like a work around. Just setting min width since it never changes.

The other changes are related to developers having different print width settings in lint config. Current setting should be 80.