### PR TITLE
CCUI-2902 #comment Put fill behind full screen image

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
@@ -408,6 +408,7 @@ function RC5Player() {
           }}
           id="full screen"
           style={{
+            backgroundColor: '#000000',
             position: 'absolute',
             zIndex: 9999,
             width: '100vw',
@@ -434,7 +435,7 @@ function RC5Player() {
           />
           <Typography
             variant="caption"
-            color="text.secondary"
+            color="common.white"
             sx={{ padding: '6px', position: 'absolute', left: 0, bottom: 0 }}
           >
             Click Anywhere to Close


### PR DESCRIPTION
Background color behind full screen image was missing which made the layout look strange. Full screen image logic sets a max width and height based on the image source. This enabled background user interface to poke through. 