### PR TITLE
One-click preview of the current lesson in the CMI5 player, directly …

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/TabPanel.tsx
+++ b/apps/cc-cmi5-player/src/app/components/TabPanel.tsx
@@ -270,7 +270,7 @@ export default function TabPanel() {
                   <Typography
                     component="span"
                     color="text.primary"
-                    sx={{ flexGrow: 1, fontSize: '18px', fontWeight: 'bold' }}
+                    sx={{ flexGrow: 1, fontSize: '16px', fontWeight: 'bold', lineHeight:1.1 }}
                     align="center"
                   >
                     {slide.slideTitle}

--- a/apps/cc-cmi5-player/webpack.config.js
+++ b/apps/cc-cmi5-player/webpack.config.js
@@ -1,6 +1,17 @@
 const { merge } = require('webpack-merge');
 const { composePlugins, withNx } = require('@nx/webpack');
 const { withReact } = require('@nx/react');
+const path = require('path');
+const fs = require('fs');
+const AdmZip = require('adm-zip');
+
+const TEST_DIR = path.resolve(__dirname, 'src/test');
+const TEST_CONFIG_PATH = path.join(TEST_DIR, 'config.json');
+const TEST_ASSETS_PATH = path.join(TEST_DIR, 'Assets');
+
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+}
 
 // Nx plugins for webpack.
 module.exports = composePlugins(withNx(), withReact(), (config) => {
@@ -41,13 +52,146 @@ module.exports = composePlugins(withNx(), withReact(), (config) => {
         overlay: {
           runtimeErrors: (error) => {
             if (error.message.includes('ResizeObserver')) {
-              //ReactFlow Lib events can trigger this error
-              //Mostly Harmless, Prevent Overlay From Displaying
               return false;
             }
             return true;
           },
         },
+      },
+      // Allow cross-origin requests from the editor dev server (localhost:4200)
+      headers: { 'Access-Control-Allow-Origin': '*' },
+      setupMiddlewares: (middlewares, devServer) => {
+        // CORS preflight for all dev endpoints
+        devServer.app.use((req, res, next) => {
+          if (req.method === 'OPTIONS') {
+            setCors(res);
+            res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+            res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+            return res.sendStatus(204);
+          }
+          next();
+        });
+
+        // POST /test-config — fast path, no assets (content-only lessons)
+        // Body: raw AU JSON string
+        devServer.app.post('/test-config', (req, res) => {
+          setCors(res);
+          let body = '';
+          req.on('data', (chunk) => { body += chunk; });
+          req.on('end', () => {
+            try {
+              JSON.parse(body); // validate
+              fs.mkdirSync(TEST_DIR, { recursive: true });
+              fs.writeFileSync(TEST_CONFIG_PATH, body, 'utf-8');
+              res.json({ success: true });
+            } catch (err) {
+              res.status(400).json({ success: false, error: err.message });
+            }
+          });
+        });
+
+        // POST /upload-lesson-zip — full path with assets, zip bytes sent directly from browser
+        // Query param: lessonDirPath — path inside zip to the lesson folder
+        //              (e.g. "compiled_course/blocks/sandbox/intro")
+        // Body: raw zip bytes (application/octet-stream)
+        devServer.app.post('/upload-lesson-zip', (req, res) => {
+          setCors(res);
+          const lessonDirPath = req.query['lessonDirPath'];
+          if (!lessonDirPath) {
+            return res.status(400).json({ success: false, error: 'lessonDirPath query param is required' });
+          }
+
+          const chunks = [];
+          req.on('data', (chunk) => { chunks.push(chunk); });
+          req.on('end', () => {
+            try {
+              const zipBuffer = Buffer.concat(chunks);
+              const zip = new AdmZip(zipBuffer);
+
+              // Extract config.json
+              const configEntry = zip.getEntry(`${lessonDirPath}/config.json`);
+              if (!configEntry) {
+                return res.status(400).json({ success: false, error: `config.json not found at ${lessonDirPath}/config.json in zip` });
+              }
+              fs.mkdirSync(TEST_DIR, { recursive: true });
+              fs.writeFileSync(TEST_CONFIG_PATH, configEntry.getData().toString('utf-8'), 'utf-8');
+
+              // Extract Assets/ folder if present
+              const assetsPrefix = `${lessonDirPath}/Assets/`;
+              const assetEntries = zip.getEntries().filter(e => e.entryName.startsWith(assetsPrefix) && !e.isDirectory);
+              if (assetEntries.length > 0) {
+                fs.rmSync(TEST_ASSETS_PATH, { recursive: true, force: true });
+                for (const entry of assetEntries) {
+                  const relPath = entry.entryName.slice(assetsPrefix.length);
+                  const destPath = path.join(TEST_ASSETS_PATH, relPath);
+                  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+                  fs.writeFileSync(destPath, entry.getData());
+                }
+              } else {
+                fs.rmSync(TEST_ASSETS_PATH, { recursive: true, force: true });
+              }
+
+              res.json({ success: true, assetsCount: assetEntries.length });
+            } catch (err) {
+              res.status(500).json({ success: false, error: err.message });
+            }
+          });
+        });
+
+        // POST /load-course-zip — full path with assets (Electron/disk path variant)
+        // Body JSON: { zipPath: string, lessonDirPath: string }
+        //   zipPath       — absolute path to the exported zip on disk (e.g. C:\Users\...\Downloads\sandbox.zip)
+        //   lessonDirPath — path inside zip to the lesson folder
+        //                   (e.g. "compiled_course/blocks/sandbox/intro")
+        devServer.app.post('/load-course-zip', (req, res) => {
+          setCors(res);
+          let body = '';
+          req.on('data', (chunk) => { body += chunk; });
+          req.on('end', () => {
+            try {
+              const { zipPath, lessonDirPath } = JSON.parse(body);
+
+              if (!zipPath || !lessonDirPath) {
+                return res.status(400).json({ success: false, error: 'zipPath and lessonDirPath are required' });
+              }
+              if (!fs.existsSync(zipPath)) {
+                return res.status(400).json({ success: false, error: `Zip not found: ${zipPath}` });
+              }
+
+              const zip = new AdmZip(zipPath);
+
+              // Extract config.json
+              const configEntry = zip.getEntry(`${lessonDirPath}/config.json`);
+              if (!configEntry) {
+                return res.status(400).json({ success: false, error: `config.json not found at ${lessonDirPath}/config.json in zip` });
+              }
+              fs.mkdirSync(TEST_DIR, { recursive: true });
+              fs.writeFileSync(TEST_CONFIG_PATH, configEntry.getData().toString('utf-8'), 'utf-8');
+
+              // Extract Assets/ folder if present
+              const assetsPrefix = `${lessonDirPath}/Assets/`;
+              const assetEntries = zip.getEntries().filter(e => e.entryName.startsWith(assetsPrefix) && !e.isDirectory);
+              if (assetEntries.length > 0) {
+                fs.rmSync(TEST_ASSETS_PATH, { recursive: true, force: true });
+                for (const entry of assetEntries) {
+                  const relPath = entry.entryName.slice(assetsPrefix.length);
+                  const destPath = path.join(TEST_ASSETS_PATH, relPath);
+                  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+                  fs.writeFileSync(destPath, entry.getData());
+                }
+              } else {
+                // No assets in this lesson — clear stale assets from previous run
+                fs.rmSync(TEST_ASSETS_PATH, { recursive: true, force: true });
+              }
+
+              res.json({ success: true, assetsCount: assetEntries.length });
+            } catch (err) {
+              res.status(500).json({ success: false, error: err.message });
+            }
+          });
+        });
+
+        return middlewares;
       },
     },
   });

--- a/apps/rapid-cmi5-electron/src/app/api/main.preload.ts
+++ b/apps/rapid-cmi5-electron/src/app/api/main.preload.ts
@@ -24,6 +24,17 @@ export const ipc = {
       projectName,
       createAuMappings,
     ),
+  testInPlayer: (
+    auJson: string,
+    playerUrl: string,
+    configDestPath: string,
+  ) =>
+    ipcRenderer.invoke(
+      'cmi5:testInPlayer',
+      auJson,
+      playerUrl,
+      configDestPath,
+    ),
 };
 
 contextBridge.exposeInMainWorld('ipc', ipc);

--- a/apps/rapid-cmi5-electron/src/main.ts
+++ b/apps/rapid-cmi5-electron/src/main.ts
@@ -596,6 +596,28 @@ ipcMain.handle('userSettingsApi:removeCert', (_e, id: string) => {
   applyCustomCerts();
 });
 
+// Test In Player Handler — writes config.json directly from in-memory AU data,
+// then opens the player dev server in the default browser. No zip build needed.
+ipcMain.handle(
+  'cmi5:testInPlayer',
+  async (
+    _evt,
+    auJson: string,
+    playerUrl: string,
+    configDestPath: string,
+  ) => {
+    try {
+      await fs.promises.mkdir(nodePath.dirname(configDestPath), { recursive: true });
+      await fs.promises.writeFile(configDestPath, auJson, 'utf-8');
+      shell.openExternal(playerUrl);
+      return { success: true };
+    } catch (err: any) {
+      console.error('cmi5:testInPlayer failed', err);
+      return { success: false, error: err?.message ?? String(err) };
+    }
+  },
+);
+
 // CMI5 Build Handler
 ipcMain.handle(
   'cmi5Build',

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/CourseBuilderTypes.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/CourseBuilderTypes.ts
@@ -18,6 +18,7 @@ export enum MessageType {
   changeLesson = 'changeLesson',
   createCourse = 'createCourse',
   downloadCourseZip = 'downloadCourseZip',
+  testInPlayer = 'testInPlayer',
   remountLesson = 'remountLesson',
   changeCourseSettings = 'changeCourseSettings',
 }

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/GitViewer/session/GitContext.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/GitViewer/session/GitContext.tsx
@@ -197,6 +197,7 @@ interface IGitContext {
   deleteRecentProject: (id: string) => Promise<void>;
   getDirHandle: () => Promise<FileSystemDirectoryHandle | null>;
   gettingRepoStatus: boolean;
+  downloadCmi5Player?: () => Promise<any>;
 }
 
 interface tProviderProps {
@@ -1275,6 +1276,7 @@ export const GitContextProvider = (props: tProviderProps) => {
         openLocalRepo,
         deleteRecentProject,
         getDirHandle,
+        downloadCmi5Player: rapidCmi5Opts.downloadCmi5Player,
       }}
     >
       {children}

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/GitViewer/utils/fileSystem.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/GitViewer/utils/fileSystem.ts
@@ -120,6 +120,44 @@ export class GitFS {
     coursePath: string,
     zipName: string,
   ) => {
+    const zipBlob = await this.buildCmi5CourseBlob(r, coursePath);
+    saveAs(zipBlob, zipName);
+  };
+
+  /**
+   * Seeds the ZenFS cmi5 build cache with the three files that copyIndexFile
+   * needs (index.html, cfg.json, favicon.ico) by fetching them directly from
+   * the running player dev server.  This lets buildCmi5CourseBlob work without
+   * a pre-built cc-cmi5-player.zip — useful after a fresh clone or when the zip
+   * is stale.
+   */
+  seedPlayerCacheFromDevServer = async (playerUrl: string): Promise<void> => {
+    const base = playerUrl.replace(/\/$/, '');
+
+    try {
+      await this.clearDirectory(cmi5BuildCache);
+    } catch {}
+    try {
+      await this.fs.promises.rmdir(cmi5BuildCache);
+    } catch {}
+    await this.createDirRecursive(cmi5BuildCache);
+
+    for (const filename of ['index.html', 'cfg.json', 'favicon.ico']) {
+      const res = await fetch(`${base}/${filename}`);
+      if (!res.ok) throw new Error(`Failed to fetch ${filename} from player dev server (${res.status})`);
+      const buf = await res.arrayBuffer();
+      await this.fs.promises.writeFile(join(cmi5BuildCache, filename), new Uint8Array(buf));
+    }
+  };
+
+  /**
+   * Builds the CMI5 course zip and returns the raw Blob without saving to disk.
+   * Used by TestInPlayerDialog to ship the zip directly to the player dev server.
+   */
+  buildCmi5CourseBlob = async (
+    r: RepoAccessObject,
+    coursePath: string,
+  ): Promise<Blob> => {
     const repoPath = getRepoPath(r);
 
     try {
@@ -188,9 +226,7 @@ export class GitFS {
 
       const builtZip = await this.generateZip(cmi5BuildCache, '');
 
-      const zipBlob = await builtZip.generateAsync({ type: 'blob' });
-
-      saveAs(zipBlob, zipName);
+      return await builtZip.generateAsync({ type: 'blob' });
     } catch (error: any) {
       throw error;
     } finally {

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/TestInPlayerDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/TestInPlayerDialog.tsx
@@ -1,0 +1,290 @@
+import {
+  Box,
+  Button,
+  Collapse,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { useSelector, useDispatch } from 'react-redux';
+import { useContext, useState } from 'react';
+import { modal, setModal } from '@rapid-cmi5/ui';
+import {
+  courseDataCache,
+  currentAu,
+  currentBlock,
+} from '../../../../redux/courseBuilderReducer';
+import { currentRepoAccessObjectSel } from '../../../../redux/repoManagerReducer';
+import { testInPlayerModalId } from '../../../rapidcmi5_mdx/modals/constants';
+import { ModalDialog } from '@rapid-cmi5/ui';
+import { getFsInstance } from '../../GitViewer/utils/gitFsInstance';
+import { GitContext } from '../../GitViewer/session/GitContext';
+
+const DEFAULT_PLAYER_URL = 'http://localhost:4201';
+// Electron IPC fallback: path relative to repo root
+const DEFAULT_CONFIG_PATH = 'apps/cc-cmi5-player/src/test/config.json';
+
+async function loadLessonViaZip(
+  playerUrl: string,
+  zipBlob: Blob,
+  lessonDirPath: string,
+): Promise<void> {
+  const endpoint = `${playerUrl.replace(/\/$/, '')}/upload-lesson-zip?lessonDirPath=${encodeURIComponent(lessonDirPath)}`;
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: zipBlob,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`Player dev server responded ${res.status}: ${text}`);
+  }
+  const json = await res.json().catch(() => ({ success: false }));
+  if (!json.success) {
+    throw new Error(json.error ?? 'Player dev server returned success:false');
+  }
+}
+
+async function writeConfigViaHttp(playerUrl: string, auJson: string): Promise<void> {
+  const endpoint = `${playerUrl.replace(/\/$/, '')}/test-config`;
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: auJson,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`Player dev server responded ${res.status}: ${text}`);
+  }
+  const json = await res.json().catch(() => ({ success: false }));
+  if (!json.success) {
+    throw new Error(json.error ?? 'Player dev server returned success:false');
+  }
+}
+
+async function writeConfigViaIpc(
+  auJson: string,
+  playerUrl: string,
+  configPath: string,
+): Promise<void> {
+  const result = await (window as any).ipc.testInPlayer(auJson, playerUrl, configPath);
+  if (!result?.success) {
+    throw new Error(result?.error ?? 'IPC call returned success:false');
+  }
+}
+
+export function TestInPlayerDialog() {
+  const dispatch = useDispatch();
+  const { currentCourse, downloadCmi5Player } = useContext(GitContext);
+  const repoAccessObject = useSelector(currentRepoAccessObjectSel);
+  const modalObj = useSelector(modal);
+  const courseData = useSelector(courseDataCache);
+  const currentAuIndex = useSelector(currentAu);
+  const currentBlockIndex = useSelector(currentBlock);
+
+  const [playerUrl, setPlayerUrl] = useState(DEFAULT_PLAYER_URL);
+  const [configPath, setConfigPath] = useState(DEFAULT_CONFIG_PATH);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [rebuildPlayerZip, setRebuildPlayerZip] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedBlock = courseData?.blocks?.[currentBlockIndex];
+  const currentLesson = selectedBlock?.aus?.[currentAuIndex];
+  const hasIpc = typeof (window as any).ipc?.testInPlayer === 'function';
+
+  const handleClose = () => {
+    setError(null);
+    setStatusMsg(null);
+    dispatch(setModal({ type: '', id: null, name: null }));
+  };
+
+  const handleLaunch = async () => {
+    if (!currentLesson) {
+      setError('No lesson selected.');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setStatusMsg(null);
+
+    try {
+      const fsInstance = getFsInstance();
+
+      if (hasIpc) {
+        // Electron: write config via IPC (no assets in this path)
+        const auJson = JSON.stringify(currentLesson, null, 2);
+        await writeConfigViaIpc(auJson, playerUrl, configPath);
+      } else if (repoAccessObject && currentCourse?.basePath) {
+        // Browser: build zip in-memory, ship to player dev server (includes assets)
+        if (rebuildPlayerZip && downloadCmi5Player) {
+          setStatusMsg('Downloading player zip…');
+          await fsInstance.downloadCmi5PlayerIfNeeded(downloadCmi5Player);
+        } else {
+          setStatusMsg('Seeding player cache from dev server…');
+          await fsInstance.seedPlayerCacheFromDevServer(playerUrl);
+        }
+
+        setStatusMsg('Building course zip…');
+
+        // dirPath on the AU is relative (e.g. "sandbox/intro")
+        const lessonDirPath = `compiled_course/blocks/${currentLesson.dirPath}`;
+
+        const zipBlob = await fsInstance.buildCmi5CourseBlob(
+          repoAccessObject,
+          currentCourse.basePath,
+        );
+
+        setStatusMsg('Uploading to player…');
+        await loadLessonViaZip(playerUrl, zipBlob, lessonDirPath);
+      } else {
+        // Fallback: content-only (no assets)
+        const auJson = JSON.stringify(currentLesson, null, 2);
+        await writeConfigViaHttp(playerUrl, auJson);
+      }
+
+      window.open(playerUrl, '_blank');
+      handleClose();
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+    } finally {
+      setIsLoading(false);
+      setStatusMsg(null);
+    }
+  };
+
+  const lessonLabel = currentLesson
+    ? `${selectedBlock?.blockName ?? ''} / ${currentLesson.auName}`
+    : 'No lesson selected';
+
+  return (
+    <ModalDialog
+      testId={testInPlayerModalId}
+      buttons={[]}
+      dialogProps={{
+        open: modalObj.type === testInPlayerModalId,
+        maxWidth: 'sm',
+        fullWidth: true,
+      }}
+    >
+      <>
+        <DialogTitle>Test In Player</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
+            Publishes the current lesson (including assets) to the player dev
+            server and opens it in a new tab. Make sure{' '}
+            <code>nx serve cc-cmi5-player</code> is running.
+          </Typography>
+
+          <Typography variant="caption" display="block" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+            Lesson
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{
+              mb: 2,
+              px: 1.5,
+              py: 1,
+              borderRadius: 1,
+              bgcolor: 'action.hover',
+              fontFamily: 'monospace',
+              fontSize: '0.8rem',
+            }}
+          >
+            {lessonLabel}
+          </Typography>
+
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', mb: 1 }}
+            onClick={() => setShowAdvanced((v) => !v)}
+          >
+            <Typography variant="caption" sx={{ fontWeight: 'bold', mr: 0.5 }}>
+              Advanced
+            </Typography>
+            {showAdvanced ? (
+              <ExpandLessIcon fontSize="small" />
+            ) : (
+              <ExpandMoreIcon fontSize="small" />
+            )}
+          </Box>
+
+          <Collapse in={showAdvanced}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 0.5 }}>
+              <TextField
+                label="Player URL"
+                value={playerUrl}
+                onChange={(e) => setPlayerUrl(e.target.value)}
+                size="small"
+                fullWidth
+                helperText="URL of the running cc-cmi5-player dev server"
+              />
+              {hasIpc && (
+                <TextField
+                  label="Config destination path"
+                  value={configPath}
+                  onChange={(e) => setConfigPath(e.target.value)}
+                  size="small"
+                  fullWidth
+                  helperText="Electron only — path relative to repo root"
+                />
+              )}
+              <FormControlLabel
+                control={
+                  <Switch
+                    size="small"
+                    checked={rebuildPlayerZip}
+                    onChange={(e) => setRebuildPlayerZip(e.target.checked)}
+                  />
+                }
+                label={
+                  <Box>
+                    <Typography variant="caption">Use player zip asset</Typography>
+                    <Typography variant="caption" display="block" color="text.secondary">
+                      Off: fetch index.html/cfg.json directly from the dev server (works after a fresh clone).
+                      On: use the pre-built <code>cc-cmi5-player.zip</code> from assets (run <code>npm run build:player-for-editor</code> if stale).
+                    </Typography>
+                  </Box>
+                }
+              />
+            </Box>
+          </Collapse>
+
+          {statusMsg && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+              {statusMsg}
+            </Typography>
+          )}
+
+          {error && (
+            <Typography variant="body2" color="error" sx={{ mt: 1.5 }}>
+              {error}
+            </Typography>
+          )}
+        </DialogContent>
+
+        <DialogActions>
+          <Button onClick={handleClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleLaunch}
+            disabled={isLoading || !currentLesson}
+          >
+            {isLoading ? 'Launching…' : 'Launch'}
+          </Button>
+        </DialogActions>
+      </>
+    </ModalDialog>
+  );
+}
+
+export default TestInPlayerDialog;

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/TestInPlayerDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/TestInPlayerDialog.tsx
@@ -51,7 +51,10 @@ async function loadLessonViaZip(
   }
 }
 
-async function writeConfigViaHttp(playerUrl: string, auJson: string): Promise<void> {
+async function writeConfigViaHttp(
+  playerUrl: string,
+  auJson: string,
+): Promise<void> {
   const endpoint = `${playerUrl.replace(/\/$/, '')}/test-config`;
   const res = await fetch(endpoint, {
     method: 'POST',
@@ -73,7 +76,11 @@ async function writeConfigViaIpc(
   playerUrl: string,
   configPath: string,
 ): Promise<void> {
-  const result = await (window as any).ipc.testInPlayer(auJson, playerUrl, configPath);
+  const result = await (window as any).ipc.testInPlayer(
+    auJson,
+    playerUrl,
+    configPath,
+  );
   if (!result?.success) {
     throw new Error(result?.error ?? 'IPC call returned success:false');
   }
@@ -178,13 +185,20 @@ export function TestInPlayerDialog() {
       <>
         <DialogTitle>Test In Player</DialogTitle>
         <DialogContent>
-          <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
+          <Typography
+            variant="body2"
+            sx={{ mb: '4px', color: 'text.secondary' }}
+          >
             Publishes the current lesson (including assets) to the player dev
             server and opens it in a new tab. Make sure{' '}
             <code>nx serve cc-cmi5-player</code> is running.
           </Typography>
 
-          <Typography variant="caption" display="block" sx={{ mb: 0.5, fontWeight: 'bold' }}>
+          <Typography
+            variant="caption"
+            display="block"
+            sx={{ paddingTop: '8px', mb: 0.5, fontWeight: 'bold' }}
+          >
             Lesson
           </Typography>
           <Typography
@@ -203,7 +217,12 @@ export function TestInPlayerDialog() {
           </Typography>
 
           <Box
-            sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', mb: 1 }}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              cursor: 'pointer',
+              mb: 1,
+            }}
             onClick={() => setShowAdvanced((v) => !v)}
           >
             <Typography variant="caption" sx={{ fontWeight: 'bold', mr: 0.5 }}>
@@ -217,9 +236,16 @@ export function TestInPlayerDialog() {
           </Box>
 
           <Collapse in={showAdvanced}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 0.5 }}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1.5,
+                mt: 0.5,
+              }}
+            >
               <TextField
-                label="Player URL"
+                label="CMI5 Player URL"
                 value={playerUrl}
                 onChange={(e) => setPlayerUrl(e.target.value)}
                 size="small"
@@ -246,10 +272,20 @@ export function TestInPlayerDialog() {
                 }
                 label={
                   <Box>
-                    <Typography variant="caption">Use player zip asset</Typography>
-                    <Typography variant="caption" display="block" color="text.secondary">
-                      Off: fetch index.html/cfg.json directly from the dev server (works after a fresh clone).
-                      On: use the pre-built <code>cc-cmi5-player.zip</code> from assets (run <code>npm run build:player-for-editor</code> if stale).
+                    <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+                      Use player zip asset
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      display="block"
+                      color="text.secondary"
+                    >
+                      Off: Fetch index.html/cfg.json directly from the dev
+                      server (works after a fresh clone).
+                      <br />
+                      On: Use the pre-built <code>cc-cmi5-player.zip</code> from
+                      assets (run <code>npm run build:player-for-editor</code>{' '}
+                      if stale).
                     </Typography>
                   </Box>
                 }

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/git/SelectGitDialogs.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/git/SelectGitDialogs.tsx
@@ -31,10 +31,14 @@ import {
   downloadCmi5ZipModalId,
   setGitConfigModalId,
   gitPushModalId,
+  testInPlayerModalId,
 } from '../../../rapidcmi5_mdx/modals/constants';
+import { GitContext } from '../../GitViewer/session/GitContext';
+import CourseSelector from '../../selectors/CourseSelector';
 import CreateCourseForm from '../courses/CreateCourseForm';
 import CreateLessonForm from '../courses/CreateLessonForm';
 import DownloadCmi5ZipForm from '../courses/DownloadCmi5ZipForm';
+import TestInPlayerDialog from '../courses/TestInPlayerDialog';
 import ImportRepoZipForm from '../courses/ImportRepoZipForm';
 import CloneRepoForm from './CloneRepoForm';
 import CommitForm from './CommitForm';
@@ -44,9 +48,7 @@ import PullForm from './PullForm';
 import PushForm from './PushForm';
 import DirectoryTree from '../../GitViewer/Components/SelectedRepo/DirectoryTree';
 import { RepoState, RootState } from '@rapid-cmi5/react-editor';
-import { GitContext } from '../../GitViewer/session/GitContext';
 import { useRapidCmi5Opts } from '../../GitViewer/session/RapidCmi5OptsContext';
-import CourseSelector from '../../selectors/CourseSelector';
 
 /**
  * Select Repo, Course, AU
@@ -393,6 +395,7 @@ export function SelectGitDialogs() {
           handleModalAction={handleModalResponse}
         />
       )}
+      {modalObj.type === testInPlayerModalId && <TestInPlayerDialog />}
       {/* prompt set config */}
       {modalObj.type === setGitConfigModalId && (
         <GitConfigForm

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/contexts/RC5Context.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/contexts/RC5Context.tsx
@@ -18,6 +18,7 @@ import {
   createCourseModalId,
   downloadCmi5ZipModalId,
   saveCourseFileModalId,
+  testInPlayerModalId,
   warningModalId,
 } from '../modals/constants';
 import { ILessonNode } from '../drawers/components/LessonTreeNode';
@@ -524,6 +525,15 @@ export const RC5ContextProvider: any = (props: tProviderProps) => {
             meta: {
               title: 'Download Course Zip',
             },
+          }),
+        );
+        break;
+      case MessageType.testInPlayer:
+        dispatch(
+          setModal({
+            type: testInPlayerModalId,
+            id: null,
+            name: null,
           }),
         );
         break;

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/drawers/LessonDrawer.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/drawers/LessonDrawer.tsx
@@ -321,38 +321,6 @@ export const LessonDrawer = () => {
               </span>
             </Tooltip>
 
-            {process.env['NODE_ENV'] === 'development' && (
-              <Tooltip title="Test Current Lesson In Player">
-                <span>
-                  <IconButton
-                    aria-label="test in player"
-                    id="test-in-player"
-                    data-testid="test-in-player"
-                    disabled={!currentRepo || !currentCourse?.basePath}
-                    onClick={() => {
-                      saveSlide();
-                      promptTestInPlayer();
-                    }}
-                    size="small"
-                    sx={(theme) => ({
-                      borderRadius: 1,
-                      border: `1px solid ${theme.palette.success.main}`,
-                      color: 'success.main',
-                      transition:
-                        'transform 120ms ease, background-color 120ms ease',
-                      '&:hover': {
-                        bgcolor: alpha(theme.palette.success.main, 0.15),
-                        transform: 'translateY(-1px)',
-                      },
-                      '&.Mui-disabled': { opacity: 0.45 },
-                    })}
-                  >
-                    <PlayCircleOutlineIcon fontSize="small" />
-                  </IconButton>
-                </span>
-              </Tooltip>
-            )}
-
             <ButtonOptions
               optionButton={(handleClick: any) => (
                 <Tooltip title="Course Options">

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/drawers/LessonDrawer.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/drawers/LessonDrawer.tsx
@@ -36,6 +36,7 @@ import FolderZipIcon from '@mui/icons-material/FolderZip';
 import ImportExportIcon from '@mui/icons-material/ImportExport';
 import IosShareIcon from '@mui/icons-material/IosShare';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
+import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 
 
 import { debugLogError, RowAction } from '@rapid-cmi5/ui';
@@ -72,6 +73,7 @@ export const LessonDrawer = () => {
     promptCreateLesson,
     promptDeleteCourse,
     promptDownloadCourseCMI5Zip,
+    promptTestInPlayer,
   } = useRC5Prompts();
 
   const [menuAnchor, setMenuAnchor] = useState<any>(null);
@@ -318,6 +320,38 @@ export const LessonDrawer = () => {
                 </IconButton>
               </span>
             </Tooltip>
+
+            {process.env['NODE_ENV'] === 'development' && (
+              <Tooltip title="Test Current Lesson In Player">
+                <span>
+                  <IconButton
+                    aria-label="test in player"
+                    id="test-in-player"
+                    data-testid="test-in-player"
+                    disabled={!currentRepo || !currentCourse?.basePath}
+                    onClick={() => {
+                      saveSlide();
+                      promptTestInPlayer();
+                    }}
+                    size="small"
+                    sx={(theme) => ({
+                      borderRadius: 1,
+                      border: `1px solid ${theme.palette.success.main}`,
+                      color: 'success.main',
+                      transition:
+                        'transform 120ms ease, background-color 120ms ease',
+                      '&:hover': {
+                        bgcolor: alpha(theme.palette.success.main, 0.15),
+                        transform: 'translateY(-1px)',
+                      },
+                      '&.Mui-disabled': { opacity: 0.45 },
+                    })}
+                  >
+                    <PlayCircleOutlineIcon fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            )}
 
             <ButtonOptions
               optionButton={(handleClick: any) => (

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/modals/constants.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/modals/constants.ts
@@ -25,4 +25,5 @@ export const saveCourseFileModalId = 'saveCourseFileModalId';
 export const saveCourseFileBeforeModalId = 'saveCourseFileBeforeModalId';
 export const selectRepoModalId = 'selectRepoModalId';
 export const setGitConfigModalId = 'setGitConfigModalId';
+export const testInPlayerModalId = 'testInPlayerModalId';
 export const warningModalId = 'warning';

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/modals/useRC5Prompts.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/modals/useRC5Prompts.ts
@@ -17,6 +17,7 @@ import {
   saveCourseFileBeforeModalId,
   saveCourseFileModalId,
   setGitConfigModalId,
+  testInPlayerModalId,
 } from './constants';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -262,6 +263,27 @@ export const useRC5Prompts = () => {
     }
   };
 
+  const promptTestInPlayer = () => {
+    if (hasFilesToSave) {
+      promptSaveCourseFile(
+        'Save Changes First?',
+        remindFileSystem,
+        {
+          notify: MessageType.testInPlayer,
+        },
+        saveCourseFileBeforeModalId,
+      );
+    } else {
+      dispatch(
+        setModal({
+          type: testInPlayerModalId,
+          id: null,
+          name: null,
+        }),
+      );
+    }
+  };
+
   const promptGitConfig = () => {
     dispatch(
       setModal({
@@ -342,6 +364,7 @@ export const useRC5Prompts = () => {
     promptDeleteLesson,
     promptDeleteRepo,
     promptDownloadCourseCMI5Zip,
+    promptTestInPlayer,
     promptNavAway,
     promptPublishPcteModal,
     promptSaveCourseFile,

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/RapidCmi5Toolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/RapidCmi5Toolbar.tsx
@@ -25,6 +25,7 @@ import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import ArtTrackIcon from '@mui/icons-material/ArtTrack';
 import ScreenShareIcon from '@mui/icons-material/ScreenShare';
 import { MarkdownIconSvg } from './constants';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 
 import { alpha, Box, Divider, Stack, useTheme } from '@mui/material';
 import { useSelector } from 'react-redux';
@@ -73,6 +74,7 @@ import { ListsToggle } from './components/ListsToggle';
 import { UndoRedo } from './components/UndoRedo';
 import { InsertQuotes } from './components/InsertQuotes';
 import { InsertStatements } from './components/InsertStatements';
+import { useRC5Prompts } from '../modals/useRC5Prompts';
 
 /**
  * Layout Constants
@@ -113,6 +115,8 @@ export const RapidCmi5Toolbar: React.FC = () => {
 
   const disabledIconColor = alpha((theme as any).palette.divider, 0.25);
   const activeIconColor = theme.palette.text.primary; //REFtheme.palette.primary.main;
+
+  const { promptTestInPlayer } = useRC5Prompts();
 
   /**
    * themed icon
@@ -434,6 +438,7 @@ export const RapidCmi5Toolbar: React.FC = () => {
                     }}
                   />
                 </MUIButtonWithTooltip>
+
                 <Divider
                   orientation="vertical"
                   color="divider"
@@ -449,6 +454,27 @@ export const RapidCmi5Toolbar: React.FC = () => {
                 >
                   {markDownIcon}
                 </MUIButtonWithTooltip>
+                <Divider
+                  orientation="vertical"
+                  color="divider"
+                  flexItem
+                  sx={{ mx: 0 }}
+                />
+                {process.env['NODE_ENV'] === 'development' && (
+                  <MUIButtonWithTooltip
+                    title="Launch CMI5 Player"
+                    onClick={() => {
+                      promptTestInPlayer();
+                    }}
+                  >
+                    <RocketLaunchIcon
+                      sx={{
+                        color: activeIconColor,
+                        fill: activeIconColor,
+                      }}
+                    />
+                  </MUIButtonWithTooltip>
+                )}
               </Stack>
             </Stack>
           </Stack>

--- a/scripts/_buildZip.cjs
+++ b/scripts/_buildZip.cjs
@@ -1,0 +1,32 @@
+// Helper script for buildCmi5PlayerForEditor.sh when `zip` is not available (Windows).
+// Produces a zip with forward-slash paths, compatible with JSZip extraction in the browser.
+// Usage: node _buildZip.cjs <sourceDir> <outputZipName>
+const fs = require('fs');
+const path = require('path');
+const JSZip = require(path.resolve(__dirname, '../node_modules/jszip/lib/index.js'));
+
+const [, , sourceDir, zipName] = process.argv;
+if (!sourceDir || !zipName) {
+  console.error('Usage: node _buildZip.cjs <sourceDir> <outputZipName>');
+  process.exit(1);
+}
+
+const zip = new JSZip();
+
+function addDir(dir, base) {
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const rel = (base ? base + '/' : '') + entry;
+    if (rel === zipName) continue; // skip existing zip file
+    if (fs.statSync(full).isDirectory()) { addDir(full, rel); }
+    else { zip.file(rel, fs.readFileSync(full)); }
+  }
+}
+
+addDir(sourceDir, '');
+
+zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' })
+  .then(buf => {
+    fs.writeFileSync(path.join(sourceDir, zipName), buf);
+    console.log(`zip written: ${zipName} (${buf.length} bytes)`);
+  });

--- a/scripts/buildCmi5PlayerForEditor.sh
+++ b/scripts/buildCmi5PlayerForEditor.sh
@@ -16,10 +16,19 @@ npx nx build "$APP_NAME"
 # rm -f "$DIST_DIR/$ZIP_NAME"
 # rm -f "$TARGET_ZIP"
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 echo "▶ Zipping build output..."
 (
   cd "$DIST_DIR"
-  zip -r "$ZIP_NAME" .
+  if command -v zip &>/dev/null; then
+    zip -r "$ZIP_NAME" .
+  else
+    # Fallback for Windows (Git Bash without zip)
+    # Compress-Archive uses backslash path separators which break JSZip path parsing,
+    # so use Node + JSZip to produce a zip with forward-slash paths instead.
+    node "$REPO_ROOT/scripts/_buildZip.cjs" "$(pwd)" "$ZIP_NAME"
+  fi
 )
 
 echo "▶ Copying zip to Electron assets (override)..."


### PR DESCRIPTION
…from the editor — no manual publish -> extract => move

start FE server:
nx serve rapid-cmi5-electron-frontend

start CMI5 Player (should default to http://localhost:4201 npx nx serve cc-cmi5-player

1. Open a course in the Visual Designer and navigate to the lesson you want to preview.
2. Click the green **Play** button (▷) in the lesson drawer toolbar — it appears only in Electron dev mode, to the right of the Publish button.
3. A dialog opens showing the selected lesson. Click **Launch**.
4. Your default browser opens the player dev server URL and immediately loads that lesson.

If you have unsaved changes the editor will prompt you to save first, then open the dialog.

<img width="2525" height="1156" alt="testplayerineditor" src="https://github.com/user-attachments/assets/79033e71-3218-466a-85ab-ea3ec5990122" />
