### PR TITLE
CCUI-2911 #comment Without logo entries, logo appears as a broken ima…

### DIFF
--- a/apps/cc-cmi5-player/src/cfg.json
+++ b/apps/cc-cmi5-player/src/cfg.json
@@ -13,8 +13,8 @@
         "KEYCLOAK_SCOPE": "profile",
         "THEME": {
           "SLIDE_BACKGROUND": "",
-          "LOGO_DARK": "./assets/bylight/RangeOS_Logo_Dark.png",
-          "LOGO_LIGHT": "./assets/bylight/RangeOS_Logo_Light.png"
+          "LOGO_DARK": "./assets/bylight/RapidCMI5_Logo_Dark.png",
+          "LOGO_LIGHT": "./assets/bylight/RapidCMI5_Logo_Light.png"
         }
       }
     },
@@ -30,7 +30,9 @@
         "KEYCLOAK_CLIENT_ID": "rangeos-dashboard",
         "KEYCLOAK_SCOPE": "profile",
         "THEME": {
-          "SLIDE_BACKGROUND": ""
+          "SLIDE_BACKGROUND": "",
+          "LOGO_DARK": "./assets/bylight/RapidCMI5_Logo_Dark.png",
+          "LOGO_LIGHT": "./assets/bylight/RapidCMI5_Logo_Light.png"
         }
       }
     },
@@ -40,7 +42,9 @@
       "config": {
         "DEVOPS_API_URL": "https://rangeos-api.develop-cp.rangeos.engineering",
         "DEVOPS_GQL_URL": "https://rangeos-graphql.develop-cp.rangeos.engineering/",
-        "DEVOPS_GQL_SUBSCRIPTIONS_URL": "wss:////rangeos-graphql.develop-cp.rangeos.engineering"
+        "DEVOPS_GQL_SUBSCRIPTIONS_URL": "wss:////rangeos-graphql.develop-cp.rangeos.engineering",
+        "LOGO_DARK": "./assets/bylight/RapidCMI5_Logo_Dark.png",
+        "LOGO_LIGHT": "./assets/bylight/RapidCMI5_Logo_Light.png"
       }
     },
     {
@@ -51,7 +55,9 @@
         "DEVOPS_GQL_URL": "https://rangeos-graphql.develop-cp.rangeos.engineering/",
         "DEVOPS_GQL_SUBSCRIPTIONS_URL": "wss:////rangeos-graphql.develop-cp.rangeos.engineering",
         "THEME": {
-          "SLIDE_BACKGROUND": ""
+          "SLIDE_BACKGROUND": "",
+          "LOGO_DARK": "./assets/bylight/RapidCMI5_Logo_Dark.png",
+          "LOGO_LIGHT": "./assets/bylight/RapidCMI5_Logo_Light.png"
         }
       }
     },
@@ -63,7 +69,9 @@
         "DEVOPS_GQL_URL": "https://rangeos-graphql.develop-cp.rangeos.engineering/",
         "DEVOPS_GQL_SUBSCRIPTIONS_URL": "wss:////rangeos-graphql.develop-cp.rangeos.engineering",
         "THEME": {
-          "SLIDE_BACKGROUND": ""
+          "SLIDE_BACKGROUND": "",
+          "LOGO_DARK": "./assets/bylight/RapidCMI5_Logo_Dark.png",
+          "LOGO_LIGHT": "./assets/bylight/RapidCMI5_Logo_Light.png"
         }
       }
     },


### PR DESCRIPTION
Logo in the cmi5player appears as a broken image if there are no logo entries in the cfg.json file. from Moodle.

RangeOS Environment logo settings will override the logo settings in this config.