### PR TITLE
CCUI-2962 #comment Quiz Schema

### DIFF
--- a/packages/common/src/lib/schemas/QuizContent.schema.json
+++ b/packages/common/src/lib/schemas/QuizContent.schema.json
@@ -15,19 +15,29 @@
           "$ref": "#/definitions/QuestionGrading"
         },
         "matching": {
-          "items": {
-            "$ref": "#/definitions/MatchingOption"
-          },
-          "type": "array"
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/MatchingOption"
+              },
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
         },
         "options": {
-          "items": {
-            "$ref": "#/definitions/QuizOption"
-          },
-          "type": "array"
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/QuizOption"
+              },
+              "type": "array"
+            },
+            { "type": "null" }
+          ]
         },
         "shuffleAnswers": {
-          "type": "boolean"
+          "type": ["boolean", "null"]
         }
       },
       "required": [


### PR DESCRIPTION
Quiz schema did not support null values for some of the properties (did not match types) which caused red squiggles to appear in markdown view.