### PR TITLE
CCUI-2922 #comment Added validation for class id

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/editors/forms/scenario/ScenarioForm.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/editors/forms/scenario/ScenarioForm.tsx
@@ -7,6 +7,7 @@ import {
   FormControlUIProvider,
   FormCrudType,
   FormStateType,
+  META_LABEL_GROUP,
   MiniForm,
   NAME_GROUP_OPT,
   UUID_GROUP,
@@ -28,6 +29,7 @@ import { useRapidCmi5Opts } from '../../../../course-builder/GitViewer/session/R
 import { ScenarioCard } from './ScenarioCard';
 import { NoScenarioCard } from './NoScenarioCard';
 import { toTitleCase } from '../formUtils';
+import { useEffect } from 'react';
 
 export const ScenarioForm = ({
   contextMenu,
@@ -54,8 +56,12 @@ export const ScenarioForm = ({
 
   const validationSchema = yup.object().shape({
     uuid: UUID_GROUP,
-    name: NAME_GROUP_OPT,
-    defaultClassId: NAME_GROUP_OPT,
+    name: META_LABEL_GROUP,
+    defaultClassId: yup.string().when('promptClass', {
+      is: true,
+      then: () => META_LABEL_GROUP,
+      otherwise: (schema) => schema.nullable().optional(),
+    }),
   });
 
   const onSaveAction = (data: any) => {
@@ -94,6 +100,15 @@ export const ScenarioForm = ({
       setValue('name', item.name, { shouldDirty: true });
       trigger('uuid');
     };
+
+    /**
+    * UE triggers validation on the class id field if should prompt is turned on
+    */
+    useEffect(() => {
+      if (watchPromptClass) {
+        trigger('defaultClassId');
+      }
+    }, [watchPromptClass]);
 
     return (
       // <Grid container>

--- a/packages/ui/src/lib/cmi5/mdx/constants/defaultData.ts
+++ b/packages/ui/src/lib/cmi5/mdx/constants/defaultData.ts
@@ -174,7 +174,7 @@ export const defaultDownloadFilesContent: DownloadFilesContent = {
 export const defaultScenarioContentData: RC5ScenarioContent = {
   uuid: '',
   name: '',
-  promptClass: true,
+  promptClass: false,
   moveOnCriteria: MoveOnCriteriaEnum.Completed,
 };
 

--- a/packages/ui/src/lib/validation/validation.ts
+++ b/packages/ui/src/lib/validation/validation.ts
@@ -22,6 +22,7 @@ import {
   longitudeRegex,
   macAddressErrorMessage,
   macAddressRegex,
+  metaDataLabelRegex,
   nameRegex,
   preferencedDomainNameRegex,
   resourceQuantityErrorMessage,
@@ -935,7 +936,9 @@ export const GIT_URL_GROUP = (isRequired = true) => {
           ? yup.string().nullable()
           : yup
               .string()
-              .url('Must be Valid URL starting with https:// and ending with .git')
+              .url(
+                'Must be Valid URL starting with https:// and ending with .git',
+              )
               .test(
                 'test-git-url',
                 'Must be Valid URL starting with https:// and ending with .git',
@@ -1277,6 +1280,14 @@ export const IP_GROUP = yup
     }
     return true;
   });
+
+/* Meta Label */
+export const META_LABEL_GROUP = yup
+  .string()
+  .matches(
+    metaDataLabelRegex,
+    'Entry must start and end with a letter or number, and may only contain letters, numbers, hyphens (-), underscores (_), and periods (.)',
+  );
 
 /* Resource Quantity with minimum value requirement */
 export const RESOURCE_QUANTITY_WITH_MINIMUM_GROUP = (

--- a/packages/ui/src/lib/validation/validationRegex.ts
+++ b/packages/ui/src/lib/validation/validationRegex.ts
@@ -5,7 +5,8 @@ export const accessKeySecretRegex = /^[a-zA-Z0-9+/]{40}$/;
 export const amazonMachineIdRegex = /^ami-[0-9a-fA-F]{17}$/;
 export const macAddressErrorMessage = 'ex: 11:22:33:44:55:66';
 export const macAddressRegex = /^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/;
-
+export const metaDataLabelRegex =
+  /^(([a-zA-z0-9][-a-zA-z0-9_.]*)?[a-za-z0-9])?$/;
 export const alphaNumericDashUnderscoreRegex = /^[a-zA-Z0-9\-_]*$/;
 
 export const cpeFieldRegex =


### PR DESCRIPTION
Class Id had no validation configured in the Scenario Form. If the user entered a class id with spaces, for example "class A", the entry was accepted. If the user then went to the Classes dashboard in RangeOS and tried to deploy scenarios to class A, the schedule job would fail. 

This PR also changes the default promptClass value to false. 