### PR TITLE
    CCUI-2972  LayoutGrid Causes Screen Freeze

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertAccordion.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertAccordion.tsx
@@ -5,7 +5,11 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import {
+  $getSelection,
+  $isRangeSelection,
+  $createParagraphNode,
+} from 'lexical';
 import type { LexicalEditor } from 'lexical';
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
 import type { BlockContent } from 'mdast';
@@ -58,22 +62,32 @@ export const InsertAccordion = ({ isDrawer }: { isDrawer?: boolean }) => {
     if (!editor) return;
 
     editor.update(() => {
-      const selection = $getSelection();
+      let selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      if (selection.isCollapsed()) {
-        //continue
-      } else {
-        return; //no applying tab to selection
+      if (!selection.isCollapsed()) {
+        return; //no applying accordion to selection
       }
 
-      // create children tabs content nodes
+      // TOCHeadingNode.insertAfter calls getParentOrThrow(), which throws when
+      // Lexical's insertNodes tries to splice a block next to a heading node.
+      // If the anchor's top-level block is not a plain paragraph, insert a
+      // paragraph after it and move the selection there first, so the accordion
+      // lands in the right place without triggering the heading's insertAfter.
+      const anchorNode = selection.anchor.getNode();
+      const topLevel = anchorNode.getTopLevelElement();
+      if (topLevel && topLevel.getType() !== 'paragraph') {
+        const paragraph = $createParagraphNode();
+        topLevel.insertAfter(paragraph);
+        paragraph.select();
+        selection = $getSelection() as typeof selection;
+      }
+
       const theChildMDast = convertMarkdownToMdast(
         DEFAULT_ACCORDION,
         syntaxExtensions,
       );
 
-      // create accordion node
       const mdastAccordion: ContainerDirective = {
         type: 'containerDirective',
         name: 'accordion',

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertGrid.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertGrid.tsx
@@ -6,7 +6,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -88,13 +88,20 @@ export const InsertGrid = ({ isDrawer }: { isDrawer?: boolean }) => {
     }
 
     editor.update(() => {
-      const selection = $getSelection();
+      let selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      if (selection.isCollapsed()) {
-        // Continue
-      } else {
+      if (!selection.isCollapsed()) {
         return; // No applying grid to selection
+      }
+
+      const anchorNode = selection.anchor.getNode();
+      const topLevel = anchorNode.getTopLevelElement();
+      if (topLevel && topLevel.getType() !== 'paragraph') {
+        const paragraph = $createParagraphNode();
+        topLevel.insertAfter(paragraph);
+        paragraph.select();
+        selection = $getSelection() as typeof selection;
       }
 
       // Create children grid cell nodes

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
@@ -10,8 +10,10 @@ import {
 
 import {
   $getSelection,
+  $getRoot,
   $setSelection,
   $isRangeSelection,
+  $createParagraphNode,
   LexicalNode,
 } from 'lexical';
 import type { LexicalEditor } from 'lexical';
@@ -68,7 +70,15 @@ export const InsertLayoutBox = () => {
       const selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      const block = selection.anchor.getNode().getTopLevelElementOrThrow();
+      const anchorNode = selection.anchor.getNode();
+      let block = anchorNode.getTopLevelElement();
+      if (!block) {
+        // Anchor is the RootNode itself (empty editor). Append a paragraph so
+        // we have a real block to wrap.
+        const paragraph = $createParagraphNode();
+        $getRoot().append(paragraph);
+        block = paragraph;
+      }
 
       let theNodes: LexicalNode[] = [];
       let replaceBlock = false;

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertQuotes.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertQuotes.tsx
@@ -6,7 +6,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -54,8 +54,17 @@ export const InsertQuotes = ({ isDrawer }: { isDrawer?: boolean }) => {
       // then run the insert inside that callback.
       editor.focus(() => {
         editor.update(() => {
-          const selection = $getSelection();
+          let selection = $getSelection();
           if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
+
+          const anchorNode = selection.anchor.getNode();
+          const topLevel = anchorNode.getTopLevelElement();
+          if (topLevel && topLevel.getType() !== 'paragraph') {
+            const paragraph = $createParagraphNode();
+            topLevel.insertAfter(paragraph);
+            paragraph.select();
+            selection = $getSelection() as typeof selection;
+          }
 
           // create child quotes content
           const theChildMDast = convertMarkdownToMdast(

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertStatements.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertStatements.tsx
@@ -5,7 +5,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -47,8 +47,17 @@ export const InsertStatements = ({ isDrawer }: { isDrawer?: boolean }) => {
 
       editor.focus(() => {
         editor.update(() => {
-          const selection = $getSelection();
+          let selection = $getSelection();
           if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
+
+          const anchorNode = selection.anchor.getNode();
+          const topLevel = anchorNode.getTopLevelElement();
+          if (topLevel && topLevel.getType() !== 'paragraph') {
+            const paragraph = $createParagraphNode();
+            topLevel.insertAfter(paragraph);
+            paragraph.select();
+            selection = $getSelection() as typeof selection;
+          }
 
           // create statements node
           const mdastStatements: ContainerDirective = {

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertSteps.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertSteps.tsx
@@ -5,7 +5,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
 import type { BlockContent } from 'mdast';
@@ -38,13 +38,20 @@ export const InsertSteps = ({ isDrawer }: { isDrawer?: boolean }) => {
     if (!editor) return;
 
     editor.update(() => {
-      const selection = $getSelection();
+      let selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      if (selection.isCollapsed()) {
-        //continue
-      } else {
+      if (!selection.isCollapsed()) {
         return; //no applying tab to selection
+      }
+
+      const anchorNode = selection.anchor.getNode();
+      const topLevel = anchorNode.getTopLevelElement();
+      if (topLevel && topLevel.getType() !== 'paragraph') {
+        const paragraph = $createParagraphNode();
+        topLevel.insertAfter(paragraph);
+        paragraph.select();
+        selection = $getSelection() as typeof selection;
       }
 
       // create children tabs content nodes

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertTabs.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertTabs.tsx
@@ -6,7 +6,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -46,13 +46,20 @@ export const InsertTabs = ({ isDrawer }: { isDrawer?: boolean }) => {
     if (!editor) return;
 
     editor.update(() => {
-      const selection = $getSelection();
+      let selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      if (selection.isCollapsed()) {
-        //continue
-      } else {
+      if (!selection.isCollapsed()) {
         return; //no applying tab to selection
+      }
+
+      const anchorNode = selection.anchor.getNode();
+      const topLevel = anchorNode.getTopLevelElement();
+      if (topLevel && topLevel.getType() !== 'paragraph') {
+        const paragraph = $createParagraphNode();
+        topLevel.insertAfter(paragraph);
+        paragraph.select();
+        selection = $getSelection() as typeof selection;
       }
 
       // create children tabs content nodes


### PR DESCRIPTION
work around TOCHeadingNode.insertAfter throwing in getParentOrThrow when trying to splice block to heading node.

If the anchor's top-level block is not a plain paragraph, insert a paragraph after it and move the selection there first, so the accordion lands in the right place without triggering the heading's insertAfter.