### PR TITLE
Bugfix/cc UI 2972 toc header insert exception

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertAccordion.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertAccordion.tsx
@@ -5,7 +5,11 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import {
+  $getSelection,
+  $isRangeSelection,
+  $createParagraphNode,
+} from 'lexical';
 import type { LexicalEditor } from 'lexical';
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
 import type { BlockContent } from 'mdast';
@@ -58,22 +62,32 @@ export const InsertAccordion = ({ isDrawer }: { isDrawer?: boolean }) => {
     if (!editor) return;
 
     editor.update(() => {
-      const selection = $getSelection();
+      let selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      if (selection.isCollapsed()) {
-        //continue
-      } else {
-        return; //no applying tab to selection
+      if (!selection.isCollapsed()) {
+        return; //no applying accordion to selection
       }
 
-      // create children tabs content nodes
+      // TOCHeadingNode.insertAfter calls getParentOrThrow(), which throws when
+      // Lexical's insertNodes tries to splice a block next to a heading node.
+      // If the anchor's top-level block is not a plain paragraph, insert a
+      // paragraph after it and move the selection there first, so the accordion
+      // lands in the right place without triggering the heading's insertAfter.
+      const anchorNode = selection.anchor.getNode();
+      const topLevel = anchorNode.getTopLevelElement();
+      if (topLevel && topLevel.getType() !== 'paragraph') {
+        const paragraph = $createParagraphNode();
+        topLevel.insertAfter(paragraph);
+        paragraph.select();
+        selection = $getSelection() as typeof selection;
+      }
+
       const theChildMDast = convertMarkdownToMdast(
         DEFAULT_ACCORDION,
         syntaxExtensions,
       );
 
-      // create accordion node
       const mdastAccordion: ContainerDirective = {
         type: 'containerDirective',
         name: 'accordion',

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertAccordion.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertAccordion.tsx
@@ -27,6 +27,7 @@ import {
   placeCaretInsideDirective,
 } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
+import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
 
 /** The first line return is REQUIRED!!!! */
 const DEFAULT_ACCORDION = `
@@ -54,6 +55,7 @@ export const InsertAccordion = ({ isDrawer }: { isDrawer?: boolean }) => {
   const editor = useCellValue(rootEditor$) as LexicalEditor | null;
   const [syntaxExtensions] = useCellValues(syntaxExtensions$);
   const theme = useTheme();
+  const selectionHelper = useSelectionHelper();
   /**
    * Inserts default Accordion at the current selection
    * If it is NOT empty, nothing is inserted
@@ -69,19 +71,7 @@ export const InsertAccordion = ({ isDrawer }: { isDrawer?: boolean }) => {
         return; //no applying accordion to selection
       }
 
-      // TOCHeadingNode.insertAfter calls getParentOrThrow(), which throws when
-      // Lexical's insertNodes tries to splice a block next to a heading node.
-      // If the anchor's top-level block is not a plain paragraph, insert a
-      // paragraph after it and move the selection there first, so the accordion
-      // lands in the right place without triggering the heading's insertAfter.
-      const anchorNode = selection.anchor.getNode();
-      const topLevel = anchorNode.getTopLevelElement();
-      if (topLevel && topLevel.getType() !== 'paragraph') {
-        const paragraph = $createParagraphNode();
-        topLevel.insertAfter(paragraph);
-        paragraph.select();
-        selection = $getSelection() as typeof selection;
-      }
+      selection = selectionHelper.getInsertSelection(selection);
 
       const theChildMDast = convertMarkdownToMdast(
         DEFAULT_ACCORDION,

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertGrid.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertGrid.tsx
@@ -6,7 +6,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -88,13 +88,20 @@ export const InsertGrid = ({ isDrawer }: { isDrawer?: boolean }) => {
     }
 
     editor.update(() => {
-      const selection = $getSelection();
+      let selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      if (selection.isCollapsed()) {
-        // Continue
-      } else {
+      if (!selection.isCollapsed()) {
         return; // No applying grid to selection
+      }
+
+      const anchorNode = selection.anchor.getNode();
+      const topLevel = anchorNode.getTopLevelElement();
+      if (topLevel && topLevel.getType() !== 'paragraph') {
+        const paragraph = $createParagraphNode();
+        topLevel.insertAfter(paragraph);
+        paragraph.select();
+        selection = $getSelection() as typeof selection;
       }
 
       // Create children grid cell nodes

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertGrid.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertGrid.tsx
@@ -25,6 +25,7 @@ import { ButtonMinorUi, DEFAULT_GRID } from '@rapid-cmi5/ui';
 import AddIcon from '@mui/icons-material/Add';
 import { useTheme } from '@mui/material';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
+import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
 
 /**
  * Checks if the current selection is inside a grid container or grid cell.
@@ -73,7 +74,7 @@ export const InsertGrid = ({ isDrawer }: { isDrawer?: boolean }) => {
   const editor = useCellValue(rootEditor$) as LexicalEditor | null;
   const [syntaxExtensions] = useCellValues(syntaxExtensions$);
   const theme = useTheme();
-
+  const selectionHelper = useSelectionHelper();
   /**
    * Inserts default Grid at the current selection.
    * If selection is not collapsed or inside an existing grid, nothing is inserted.
@@ -95,14 +96,7 @@ export const InsertGrid = ({ isDrawer }: { isDrawer?: boolean }) => {
         return; // No applying grid to selection
       }
 
-      const anchorNode = selection.anchor.getNode();
-      const topLevel = anchorNode.getTopLevelElement();
-      if (topLevel && topLevel.getType() !== 'paragraph') {
-        const paragraph = $createParagraphNode();
-        topLevel.insertAfter(paragraph);
-        paragraph.select();
-        selection = $getSelection() as typeof selection;
-      }
+      selection = selectionHelper.getInsertSelection(selection);
 
       // Create children grid cell nodes
       const theChildMDast = convertMarkdownToMdast(

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
@@ -10,8 +10,10 @@ import {
 
 import {
   $getSelection,
+  $getRoot,
   $setSelection,
   $isRangeSelection,
+  $createParagraphNode,
   LexicalNode,
 } from 'lexical';
 import type { LexicalEditor } from 'lexical';
@@ -68,7 +70,15 @@ export const InsertLayoutBox = () => {
       const selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      const block = selection.anchor.getNode().getTopLevelElementOrThrow();
+      const anchorNode = selection.anchor.getNode();
+      let block = anchorNode.getTopLevelElement();
+      if (!block) {
+        // Anchor is the RootNode itself (empty editor). Append a paragraph so
+        // we have a real block to wrap.
+        const paragraph = $createParagraphNode();
+        $getRoot().append(paragraph);
+        block = paragraph;
+      }
 
       let theNodes: LexicalNode[] = [];
       let replaceBlock = false;

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
@@ -31,6 +31,7 @@ import {
   placeCaretInsideDirective,
 } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
+import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
 
 const DEFAULT_MARKDOWN_OPTIONS: ToMarkdownOptions = {
   listItemIndent: 'one',
@@ -38,7 +39,7 @@ const DEFAULT_MARKDOWN_OPTIONS: ToMarkdownOptions = {
 
 export const InsertLayoutBox = () => {
   const editor = useCellValue(rootEditor$) as LexicalEditor | null;
-
+  const selectionHelper = useSelectionHelper();
   const [
     exportVisitors,
     jsxComponentDescriptors,

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertQuotes.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertQuotes.tsx
@@ -6,7 +6,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -54,8 +54,17 @@ export const InsertQuotes = ({ isDrawer }: { isDrawer?: boolean }) => {
       // then run the insert inside that callback.
       editor.focus(() => {
         editor.update(() => {
-          const selection = $getSelection();
+          let selection = $getSelection();
           if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
+
+          const anchorNode = selection.anchor.getNode();
+          const topLevel = anchorNode.getTopLevelElement();
+          if (topLevel && topLevel.getType() !== 'paragraph') {
+            const paragraph = $createParagraphNode();
+            topLevel.insertAfter(paragraph);
+            paragraph.select();
+            selection = $getSelection() as typeof selection;
+          }
 
           // create child quotes content
           const theChildMDast = convertMarkdownToMdast(

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertQuotes.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertQuotes.tsx
@@ -30,6 +30,7 @@ import {
 } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
 import { useCallback, useState } from 'react';
+import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
 
 /**
  * A toolbar button component that inserts a quotes into the editor.
@@ -40,6 +41,7 @@ export const InsertQuotes = ({ isDrawer }: { isDrawer?: boolean }) => {
   const editor = useCellValue(rootEditor$) as LexicalEditor | null;
   const [syntaxExtensions] = useCellValues(syntaxExtensions$);
   const theme: any = useTheme();
+  const selectionHelper = useSelectionHelper();
   const [isConfiguring, setIsConfiguring] = useState(false);
 
   /**
@@ -56,15 +58,7 @@ export const InsertQuotes = ({ isDrawer }: { isDrawer?: boolean }) => {
         editor.update(() => {
           let selection = $getSelection();
           if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
-
-          const anchorNode = selection.anchor.getNode();
-          const topLevel = anchorNode.getTopLevelElement();
-          if (topLevel && topLevel.getType() !== 'paragraph') {
-            const paragraph = $createParagraphNode();
-            topLevel.insertAfter(paragraph);
-            paragraph.select();
-            selection = $getSelection() as typeof selection;
-          }
+          selection = selectionHelper.getInsertSelection(selection);
 
           // create child quotes content
           const theChildMDast = convertMarkdownToMdast(

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertStatements.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertStatements.tsx
@@ -24,6 +24,7 @@ import {
 } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
 import { useCallback, useState } from 'react';
+import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
 
 /**
  * A toolbar button component that inserts a statements block into the editor.
@@ -34,6 +35,7 @@ export const InsertStatements = ({ isDrawer }: { isDrawer?: boolean }) => {
   const editor = useCellValue(rootEditor$) as LexicalEditor | null;
   const [syntaxExtensions] = useCellValues(syntaxExtensions$);
   const theme: any = useTheme();
+  const selectionHelper = useSelectionHelper();
   const [isConfiguring, setIsConfiguring] = useState(false);
 
   /**
@@ -50,14 +52,7 @@ export const InsertStatements = ({ isDrawer }: { isDrawer?: boolean }) => {
           let selection = $getSelection();
           if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
 
-          const anchorNode = selection.anchor.getNode();
-          const topLevel = anchorNode.getTopLevelElement();
-          if (topLevel && topLevel.getType() !== 'paragraph') {
-            const paragraph = $createParagraphNode();
-            topLevel.insertAfter(paragraph);
-            paragraph.select();
-            selection = $getSelection() as typeof selection;
-          }
+          selection = selectionHelper.getInsertSelection(selection);
 
           // create statements node
           const mdastStatements: ContainerDirective = {

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertStatements.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertStatements.tsx
@@ -5,7 +5,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -47,8 +47,17 @@ export const InsertStatements = ({ isDrawer }: { isDrawer?: boolean }) => {
 
       editor.focus(() => {
         editor.update(() => {
-          const selection = $getSelection();
+          let selection = $getSelection();
           if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
+
+          const anchorNode = selection.anchor.getNode();
+          const topLevel = anchorNode.getTopLevelElement();
+          if (topLevel && topLevel.getType() !== 'paragraph') {
+            const paragraph = $createParagraphNode();
+            topLevel.insertAfter(paragraph);
+            paragraph.select();
+            selection = $getSelection() as typeof selection;
+          }
 
           // create statements node
           const mdastStatements: ContainerDirective = {

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertSteps.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertSteps.tsx
@@ -5,7 +5,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
 import type { BlockContent } from 'mdast';
@@ -38,13 +38,20 @@ export const InsertSteps = ({ isDrawer }: { isDrawer?: boolean }) => {
     if (!editor) return;
 
     editor.update(() => {
-      const selection = $getSelection();
+      let selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      if (selection.isCollapsed()) {
-        //continue
-      } else {
+      if (!selection.isCollapsed()) {
         return; //no applying tab to selection
+      }
+
+      const anchorNode = selection.anchor.getNode();
+      const topLevel = anchorNode.getTopLevelElement();
+      if (topLevel && topLevel.getType() !== 'paragraph') {
+        const paragraph = $createParagraphNode();
+        topLevel.insertAfter(paragraph);
+        paragraph.select();
+        selection = $getSelection() as typeof selection;
       }
 
       // create children tabs content nodes

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertSteps.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertSteps.tsx
@@ -10,7 +10,7 @@ import type { LexicalEditor } from 'lexical';
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
 import type { BlockContent } from 'mdast';
 import { ContainerDirective } from 'mdast-util-directive';
-import { convertMarkdownToMdast, DEFAULT_STEPS, ButtonMinorUi} from '@rapid-cmi5/ui';
+import { convertMarkdownToMdast, DEFAULT_STEPS, ButtonMinorUi } from '@rapid-cmi5/ui';
 import { useTheme } from '@emotion/react';
 
 /**
@@ -19,6 +19,7 @@ import { useTheme } from '@emotion/react';
 import AddIcon from '@mui/icons-material/Add';
 import InputIcon from '@mui/icons-material/Input';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
+import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
 
 /**
  * A toolbar button component that inserts a stepper structure into the editor.
@@ -29,6 +30,7 @@ export const InsertSteps = ({ isDrawer }: { isDrawer?: boolean }) => {
   const editor = useCellValue(rootEditor$) as LexicalEditor | null;
   const [syntaxExtensions] = useCellValues(syntaxExtensions$);
   const theme: any = useTheme();
+  const selectionHelper = useSelectionHelper();
 
   /**
    * Inserts default Tabs at the current selection
@@ -45,14 +47,7 @@ export const InsertSteps = ({ isDrawer }: { isDrawer?: boolean }) => {
         return; //no applying tab to selection
       }
 
-      const anchorNode = selection.anchor.getNode();
-      const topLevel = anchorNode.getTopLevelElement();
-      if (topLevel && topLevel.getType() !== 'paragraph') {
-        const paragraph = $createParagraphNode();
-        topLevel.insertAfter(paragraph);
-        paragraph.select();
-        selection = $getSelection() as typeof selection;
-      }
+      selection = selectionHelper.getInsertSelection(selection);
 
       // create children tabs content nodes
       const theChildMDast = convertMarkdownToMdast(

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertTabs.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertTabs.tsx
@@ -27,6 +27,7 @@ import {
   DEFAULT_TABS,
 } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
+import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
 
 /**
  * A toolbar button component that inserts a tab structure into the editor.
@@ -37,7 +38,7 @@ export const InsertTabs = ({ isDrawer }: { isDrawer?: boolean }) => {
   const editor = useCellValue(rootEditor$) as LexicalEditor | null;
   const [syntaxExtensions] = useCellValues(syntaxExtensions$);
   const theme: any = useTheme();
-
+  const selectionHelper = useSelectionHelper();
   /**
    * Inserts default Tabs at the current selection
    * If it is NOT empty, nothing is inserted
@@ -53,14 +54,7 @@ export const InsertTabs = ({ isDrawer }: { isDrawer?: boolean }) => {
         return; //no applying tab to selection
       }
 
-      const anchorNode = selection.anchor.getNode();
-      const topLevel = anchorNode.getTopLevelElement();
-      if (topLevel && topLevel.getType() !== 'paragraph') {
-        const paragraph = $createParagraphNode();
-        topLevel.insertAfter(paragraph);
-        paragraph.select();
-        selection = $getSelection() as typeof selection;
-      }
+      selection = selectionHelper.getInsertSelection(selection);
 
       // create children tabs content nodes
       const theChildMDast = convertMarkdownToMdast(

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertTabs.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertTabs.tsx
@@ -6,7 +6,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection } from 'lexical';
+import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -46,13 +46,20 @@ export const InsertTabs = ({ isDrawer }: { isDrawer?: boolean }) => {
     if (!editor) return;
 
     editor.update(() => {
-      const selection = $getSelection();
+      let selection = $getSelection();
       if (!$isRangeSelection(selection)) return;
 
-      if (selection.isCollapsed()) {
-        //continue
-      } else {
+      if (!selection.isCollapsed()) {
         return; //no applying tab to selection
+      }
+
+      const anchorNode = selection.anchor.getNode();
+      const topLevel = anchorNode.getTopLevelElement();
+      if (topLevel && topLevel.getType() !== 'paragraph') {
+        const paragraph = $createParagraphNode();
+        topLevel.insertAfter(paragraph);
+        paragraph.select();
+        selection = $getSelection() as typeof selection;
       }
 
       // create children tabs content nodes

--- a/packages/rapid-cmi5/src/lib/hooks/useSelectionHelper.ts
+++ b/packages/rapid-cmi5/src/lib/hooks/useSelectionHelper.ts
@@ -1,0 +1,29 @@
+import {
+  $createParagraphNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  BaseSelection,
+  RangeSelection,
+} from 'lexical';
+
+export function useSelectionHelper() {
+  // TOCHeadingNode.insertAfter calls getParentOrThrow(), which throws when
+  // Lexical's insertNodes tries to splice a block next to a heading node.
+  // If the anchor's top-level block is not a plain paragraph, insert a
+  // paragraph after it and move the selection there first, so the accordion
+  // lands in the right place without triggering the heading's insertAfter.
+  const getInsertSelection = (selection: RangeSelection) => {
+    const anchorNode = selection.anchor.getNode();
+    const topLevel = anchorNode.getTopLevelElement();
+    if (topLevel && topLevel.getType() !== 'paragraph') {
+      const paragraph = $createParagraphNode();
+      topLevel.insertAfter(paragraph);
+      paragraph.select();
+      selection = $getSelection() as typeof selection;
+    }
+    return selection;
+  };
+
+  return { getInsertSelection };
+}


### PR DESCRIPTION
TOCHeadingNode was throwing an error when trying to insert components after a header. For these cases, we now create an empty paragraph and insert component into it.


