### PR TITLE
CCUI-2974 #comment Fix text overlap in lesson tree

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/drawers/components/LessonTreeNode.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/drawers/components/LessonTreeNode.tsx
@@ -319,7 +319,7 @@ export const LessonTreeNode: React.FC<NodeProps> = ({
         display: 'flex',
         justifyContent: 'space-between', //makes action icons align far right
         width: '100%',
-        height: '28px', //no other way to trim vertical padding on folder icons
+        minHeight: '28px', //no other way to trim vertical padding on folder icons
         color: 'text.hint',
       }}
     >
@@ -377,6 +377,7 @@ export const LessonTreeNode: React.FC<NodeProps> = ({
         <Typography
           sx={{
             ...fontStyle,
+            lineHeight: 1.2,
             color: (theme: any) =>
               `${element.isBranch ? (isCurrentLessonFolder ? focusColor : theme.palette.text.hint) : isCurrentSlide ? focusColor : theme.palette.text.hint}`,
           }}
@@ -523,7 +524,7 @@ export const LessonTreeNode: React.FC<NodeProps> = ({
                 component="nav"
               >
                 <Typography
-                  sx={{ marginLeft: '12px' }}
+                  sx={{ marginLeft: '12px', lineHeight: 1.5, height: 'auto' }}
                   variant="caption"
                 >
                   {element.name}

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/editors/forms/scenario/ScenarioForm.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/editors/forms/scenario/ScenarioForm.tsx
@@ -56,7 +56,7 @@ export const ScenarioForm = ({
 
   const validationSchema = yup.object().shape({
     uuid: UUID_GROUP,
-    name: META_LABEL_GROUP,
+    name: NAME_GROUP_OPT,
     defaultClassId: yup.string().when('promptClass', {
       is: true,
       then: () => META_LABEL_GROUP,


### PR DESCRIPTION
Resolves issue where text in the lesson tree was overlapping when the panel width is too narrow. 