### PR TITLE
CCUI-2989 credentials: 'include' flag issue

### DIFF
--- a/packages/common/src/lib/apis/hooks/useQuizBankApi.ts
+++ b/packages/common/src/lib/apis/hooks/useQuizBankApi.ts
@@ -21,8 +21,7 @@ export function useQuizBankApi(url?: string, token?: string) {
             baseUrl: url,
             baseHeaders: {
               Authorization: `Bearer ${token}`,
-            },
-            credentials: 'include',
+            }
           })
         : undefined,
     [url, token],

--- a/packages/common/src/lib/apis/hooks/useScenarioApi.ts
+++ b/packages/common/src/lib/apis/hooks/useScenarioApi.ts
@@ -22,7 +22,6 @@ export function useScenarioApi(url?: string, token?: string) {
             baseHeaders: {
               Authorization: `Bearer ${token}`,
             },
-            credentials: 'include',
           })
         : undefined,
     [url, token],


### PR DESCRIPTION
The credentials: 'include' flag in quiz and scenario queries was making the browser apply the strictest CORS rules (no wildcard origin, must have Allow-Credentials header), which the API doesn't satisfy. When publishing lesson AUs with scenarios, the AU mapping generation would fail.

Since we are using Bearer token auth, we don't need cookies to be sent.