### PR TITLE
fix: Correct eslint paths and fix imports

### DIFF
--- a/packages/common/.eslintrc.json
+++ b/packages/common/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../../.eslintrc.json"],
+  "extends": ["../../.eslintrc.json"],
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["packages/common/tsconfig.*?.json"]
+      },
       "rules": {
         "@typescript-eslint/no-floating-promises": ["error"]
       }

--- a/packages/rapid-cmi5/.eslintrc.json
+++ b/packages/rapid-cmi5/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../../.eslintrc.json"],
+  "extends": ["../../.eslintrc.json"],
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {
@@ -8,6 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["packages/rapid-cmi5/tsconfig.*?.json"]
+      },
       "rules": {
         "@typescript-eslint/no-floating-promises": ["error"]
       }

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertAccordion.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertAccordion.tsx
@@ -22,12 +22,9 @@ import { ButtonMinorUi } from '@rapid-cmi5/ui';
 import AddIcon from '@mui/icons-material/Add';
 import ViewStreamIcon from '@mui/icons-material/ViewStream';
 import { useTheme } from '@mui/material';
-import {
-  convertMarkdownToMdast,
-  placeCaretInsideDirective,
-} from '@rapid-cmi5/ui';
+import { convertMarkdownToMdast } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
-import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
+import { useSelectionHelper } from '../../../../hooks/useSelectionHelper';
 
 /** The first line return is REQUIRED!!!! */
 const DEFAULT_ACCORDION = `

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertGrid.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertGrid.tsx
@@ -6,7 +6,7 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
+import { $getSelection, $isRangeSelection } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -25,7 +25,7 @@ import { ButtonMinorUi, DEFAULT_GRID } from '@rapid-cmi5/ui';
 import AddIcon from '@mui/icons-material/Add';
 import { useTheme } from '@mui/material';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
-import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
+import { useSelectionHelper } from '../../../../hooks/useSelectionHelper';
 
 /**
  * Checks if the current selection is inside a grid container or grid cell.

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertLayoutBox.tsx
@@ -18,7 +18,6 @@ import {
 } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
-
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
 import ViewComfyIcon from '@mui/icons-material/ViewComfy';
 import type { BlockContent } from 'mdast';
@@ -31,7 +30,6 @@ import {
   placeCaretInsideDirective,
 } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
-import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
 
 const DEFAULT_MARKDOWN_OPTIONS: ToMarkdownOptions = {
   listItemIndent: 'one',
@@ -39,7 +37,6 @@ const DEFAULT_MARKDOWN_OPTIONS: ToMarkdownOptions = {
 
 export const InsertLayoutBox = () => {
   const editor = useCellValue(rootEditor$) as LexicalEditor | null;
-  const selectionHelper = useSelectionHelper();
   const [
     exportVisitors,
     jsxComponentDescriptors,

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertQuotes.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertQuotes.tsx
@@ -1,12 +1,11 @@
 import {
-  ButtonWithTooltip,
   rootEditor$,
   $createDirectiveNode,
   DirectiveNode,
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
+import { $getSelection, $isRangeSelection } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -24,13 +23,12 @@ import {
   convertMarkdownToMdast,
   ButtonMinorUi,
   QuotesSettings,
-  debugLogWarning,
   DEFAULT_QUOTES,
   QuotePreset,
 } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
 import { useCallback, useState } from 'react';
-import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
+import { useSelectionHelper } from '../../../../hooks/useSelectionHelper';
 
 /**
  * A toolbar button component that inserts a quotes into the editor.
@@ -100,10 +98,13 @@ export const InsertQuotes = ({ isDrawer }: { isDrawer?: boolean }) => {
   /**
    * Saves changes by inserting new node and removing original.
    */
-  const handleSelect = useCallback((preset: QuotePreset, avatar: string) => {
-    insertAtSelection(preset.id, avatar);
-    setIsConfiguring(false);
-  }, [insertAtSelection]);
+  const handleSelect = useCallback(
+    (preset: QuotePreset, avatar: string) => {
+      insertAtSelection(preset.id, avatar);
+      setIsConfiguring(false);
+    },
+    [insertAtSelection],
+  );
 
   /**
    * Set flag for configuring layout

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertStatements.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertStatements.tsx
@@ -1,11 +1,10 @@
 import {
   rootEditor$,
   $createDirectiveNode,
-  DirectiveNode,
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
+import { $getSelection, $isRangeSelection } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -24,7 +23,7 @@ import {
 } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
 import { useCallback, useState } from 'react';
-import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
+import { useSelectionHelper } from '../../../../hooks/useSelectionHelper';
 
 /**
  * A toolbar button component that inserts a statements block into the editor.

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertSteps.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertSteps.tsx
@@ -5,12 +5,16 @@ import {
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
+import { $getSelection, $isRangeSelection } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
 import type { BlockContent } from 'mdast';
 import { ContainerDirective } from 'mdast-util-directive';
-import { convertMarkdownToMdast, DEFAULT_STEPS, ButtonMinorUi } from '@rapid-cmi5/ui';
+import {
+  convertMarkdownToMdast,
+  DEFAULT_STEPS,
+  ButtonMinorUi,
+} from '@rapid-cmi5/ui';
 import { useTheme } from '@emotion/react';
 
 /**
@@ -19,7 +23,7 @@ import { useTheme } from '@emotion/react';
 import AddIcon from '@mui/icons-material/Add';
 import InputIcon from '@mui/icons-material/Input';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
-import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
+import { useSelectionHelper } from '../../../../hooks/useSelectionHelper';
 
 /**
  * A toolbar button component that inserts a stepper structure into the editor.

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertTabs.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/components/InsertTabs.tsx
@@ -1,12 +1,11 @@
 import {
-  ButtonWithTooltip,
   rootEditor$,
   $createDirectiveNode,
   DirectiveNode,
   syntaxExtensions$,
 } from '@mdxeditor/editor';
 
-import { $getSelection, $isRangeSelection, $createParagraphNode } from 'lexical';
+import { $getSelection, $isRangeSelection } from 'lexical';
 import type { LexicalEditor } from 'lexical';
 
 import { useCellValue, useCellValues } from '@mdxeditor/gurx';
@@ -27,7 +26,7 @@ import {
   DEFAULT_TABS,
 } from '@rapid-cmi5/ui';
 import { MUIButtonWithTooltip } from './MUIButtonWithTooltip';
-import { useSelectionHelper } from 'packages/rapid-cmi5/src/lib/hooks/useSelectionHelper';
+import { useSelectionHelper } from '../../../../hooks/useSelectionHelper';
 
 /**
  * A toolbar button component that inserts a tab structure into the editor.

--- a/packages/ui/.eslintrc.json
+++ b/packages/ui/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["plugin:@nx/react", "../../../../.eslintrc.json"],
+  "extends": ["plugin:@nx/react", "../../.eslintrc.json"],
   "ignorePatterns": ["!**/*", "storybook-static"],
   "overrides": [
     {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -109,3 +109,4 @@ export * from './lib/cmi5/mdx/util/conversion';
 export * from './lib/colors/ColorSelectionPopover';
 export * from './lib/cmi5/mdx/plugins/shared/BlockAppearanceForm';
 export * from './lib/cmi5/mdx/components/AlignmentToolbarControls';
+export * from './lib/colors/BackgroundColorTrigger';

--- a/packages/ui/src/lib/cmi5/mdx/plugins/accordion/AccordionEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/accordion/AccordionEditor.tsx
@@ -66,8 +66,8 @@ import { ContentWidthEnum } from '@rapid-cmi5/cmi5-build-common';
 import { ColorSelectionPopover } from '../../../../colors/ColorSelectionPopover';
 import { SHAPE_PRESET_COLORS } from '../../constants/colors';
 import { useGutterRight } from '../shared/useGutterRight';
-import { useBackgroundColors } from 'packages/ui/src/lib/hooks/useBackgroundColors';
-import { BackgroundColorTrigger } from 'packages/ui/src/lib/colors/BackgroundColorTrigger';
+import { BackgroundColorTrigger, useBackgroundColors } from '@rapid-cmi5/ui';
+
 /**
  * Accordion Editor for accordion directives
  * @param param0
@@ -343,12 +343,12 @@ export const AccordionEditor: React.FC<
   // Outer box: full-width background color band when backgroundColor is set.
   const outerSx: SxProps = backgroundColor
     ? {
-      boxShadow: `0 0 0 100vmax ${backgroundColor}`,
-      clipPath: `inset(0 -100vmax 0)`,
-      backgroundColor,
-      paddingTop: blockPadding,
-      paddingBottom: blockPadding,
-    }
+        boxShadow: `0 0 0 100vmax ${backgroundColor}`,
+        clipPath: `inset(0 -100vmax 0)`,
+        backgroundColor,
+        paddingTop: blockPadding,
+        paddingBottom: blockPadding,
+      }
     : {};
 
   const innerSx: SxProps = blockMaxWidth
@@ -369,10 +369,10 @@ export const AccordionEditor: React.FC<
           : {})}
         {...(contentWidth !== undefined
           ? {
-            style: {
-              '--block-max-width': blockMaxWidth ?? 'none',
-            } as CSSProperties,
-          }
+              style: {
+                '--block-max-width': blockMaxWidth ?? 'none',
+              } as CSSProperties,
+            }
           : {})}
         sx={{
           padding: 0,
@@ -424,7 +424,9 @@ export const AccordionEditor: React.FC<
               </IconButton>
             </Tooltip>
             <BackgroundColorTrigger
-              currentColor={backgroundColor ? { color: pendingColor } : undefined}
+              currentColor={
+                backgroundColor ? { color: pendingColor } : undefined
+              }
               onTrigger={openPicker}
             />
             <InsertLineReturnButton

--- a/packages/ui/src/lib/cmi5/mdx/plugins/grid/GridContainerEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/grid/GridContainerEditor.tsx
@@ -48,14 +48,16 @@ import {
 import { createGridCell, findMatchingPreset, GRID_PRESETS } from './constants';
 import { GridContextProvider } from './GridContext';
 import { LessonThemeContext } from '../../contexts/LessonThemeContext';
-import { resolveLessonThemeCSS, resolveBlockMaxWidth } from '../../../../styles/lessonThemeStyles';
+import {
+  resolveLessonThemeCSS,
+  resolveBlockMaxWidth,
+} from '../../../../styles/lessonThemeStyles';
 import { useGutterRight } from '../shared/useGutterRight';
 import { BlockAppearanceForm } from '../shared/BlockAppearanceForm';
 import { ContentWidthEnum } from '@rapid-cmi5/cmi5-build-common';
 import { ColorSelectionPopover } from '../../../../colors/ColorSelectionPopover';
 import { SHAPE_PRESET_COLORS } from '../../constants/colors';
-import { BackgroundColorTrigger } from 'packages/ui/src/lib/colors/BackgroundColorTrigger';
-import { useBackgroundColors } from 'packages/ui/src/lib/hooks/useBackgroundColors';
+import { BackgroundColorTrigger, useBackgroundColors } from '@rapid-cmi5/ui';
 
 /**
  * Grid Container Editor for grid layout directive.
@@ -73,12 +75,15 @@ export const GridContainerEditor: React.FC<
   const blockPadding = resolvedThemeCSS
     ? (resolvedThemeCSS.blockPadding ?? '0px')
     : '32px';
-  const [contentWidth, setContentWidth] = useState<ContentWidthEnum | undefined>(
-    mdastNode?.attributes?.contentWidth,
-  );
+  const [contentWidth, setContentWidth] = useState<
+    ContentWidthEnum | undefined
+  >(mdastNode?.attributes?.contentWidth);
   const [blockAppearanceOpen, setBlockAppearanceOpen] = useState(false);
   const blockMaxWidth = resolveBlockMaxWidth(contentWidth);
-  const { containerRef, menuRight } = useGutterRight(resolvedThemeCSS, blockMaxWidth);
+  const { containerRef, menuRight } = useGutterRight(
+    resolvedThemeCSS,
+    blockMaxWidth,
+  );
 
   const [sxProps, setSxProps] = useState<SxProps>({});
   const [formData, setFormData] = useState<Array<GridCellDirectiveNode>>(
@@ -87,7 +92,6 @@ export const GridContainerEditor: React.FC<
   const insertMarkdown = usePublisher(insertMarkdown$);
   const [isConfiguring, setIsConfiguring] = useState(false);
   const [isPlayback] = useCellValues(editorInPlayback$);
-
 
   const {
     backgroundColor,
@@ -166,7 +170,11 @@ export const GridContainerEditor: React.FC<
    * Used by both handleSubmit (layout changes) and color picker.
    */
   const rebuildNode = useCallback(
-    async (cells: GridCellDirectiveNode[], bgColor: string, blockContentWidth?: ContentWidthEnum) => {
+    async (
+      cells: GridCellDirectiveNode[],
+      bgColor: string,
+      blockContentWidth?: ContentWidthEnum,
+    ) => {
       if (!parentEditor) return;
 
       parentEditor.update(() => {
@@ -232,7 +240,14 @@ export const GridContainerEditor: React.FC<
     setIsConfiguring(false);
     const newCells = migrateContent(formData, selectedPreset);
     await rebuildNode(newCells, backgroundColor, contentWidth);
-  }, [rebuildNode, migrateContent, formData, selectedPreset, backgroundColor, contentWidth]);
+  }, [
+    rebuildNode,
+    migrateContent,
+    formData,
+    selectedPreset,
+    backgroundColor,
+    contentWidth,
+  ]);
 
   /**
    * Clears the background color
@@ -292,20 +307,28 @@ export const GridContainerEditor: React.FC<
   // Outer box: full-width background color band when backgroundColor is set.
   const outerSx: SxProps = backgroundColor
     ? {
-      boxShadow: `0 0 0 100vmax ${backgroundColor}`,
-      clipPath: `inset(0 -100vmax 0)`,
-      backgroundColor,
-      paddingTop: blockPadding,
-      paddingBottom: blockPadding,
-    }
+        boxShadow: `0 0 0 100vmax ${backgroundColor}`,
+        clipPath: `inset(0 -100vmax 0)`,
+        backgroundColor,
+        paddingTop: blockPadding,
+        paddingBottom: blockPadding,
+      }
     : {};
 
   return (
     <>
       <Box
         {...(backgroundColor ? { 'data-bgcolor': 'true' } : {})}
-        {...(contentWidth !== undefined ? { 'data-block-override': 'true' } : {})}
-        {...(contentWidth !== undefined ? { style: { '--block-max-width': blockMaxWidth ?? 'none' } as CSSProperties } : {})}
+        {...(contentWidth !== undefined
+          ? { 'data-block-override': 'true' }
+          : {})}
+        {...(contentWidth !== undefined
+          ? {
+              style: {
+                '--block-max-width': blockMaxWidth ?? 'none',
+              } as CSSProperties,
+            }
+          : {})}
         sx={{
           position: 'relative',
           padding: 0,
@@ -328,7 +351,13 @@ export const GridContainerEditor: React.FC<
             borderColor: 'divider',
             borderRadius: 1,
             backgroundColor: (theme) => theme.palette.background.paper,
-            ...(blockMaxWidth ? { maxWidth: blockMaxWidth, marginLeft: 'auto', marginRight: 'auto' } : {}),
+            ...(blockMaxWidth
+              ? {
+                  maxWidth: blockMaxWidth,
+                  marginLeft: 'auto',
+                  marginRight: 'auto',
+                }
+              : {}),
           }}
         >
           {/* Grid layout using CSS Grid - equal-width columns based on cell count */}
@@ -359,7 +388,6 @@ export const GridContainerEditor: React.FC<
         {/* Gutter buttons — absolutely positioned outside decorator at S/M, inside at L/None */}
         {!isPlayback && (
           <Box
-
             sx={{
               backgroundColor:
                 muiTheme.palette.mode === 'dark' ? '#282b30e6' : '#EEEEEEe6',
@@ -383,7 +411,9 @@ export const GridContainerEditor: React.FC<
               </IconButton>
             </Tooltip>
             <BackgroundColorTrigger
-              currentColor={backgroundColor ? { color: pendingColor } : undefined}
+              currentColor={
+                backgroundColor ? { color: pendingColor } : undefined
+              }
               onTrigger={openPicker}
             />
             <InsertLineReturnButton
@@ -447,15 +477,21 @@ export const GridContainerEditor: React.FC<
         onClose={() => setBlockAppearanceOpen(false)}
         onSave={(newContentWidth) => {
           setContentWidth(newContentWidth);
-          parentEditor.update(() => {
-            const attrs = { ...mdastNode.attributes } as Record<string, string>;
-            if (newContentWidth) {
-              attrs['contentWidth'] = newContentWidth;
-            } else {
-              delete attrs['contentWidth'];
-            }
-            lexicalNode.setMdastNode({ ...mdastNode, attributes: attrs });
-          }, { discrete: true });
+          parentEditor.update(
+            () => {
+              const attrs = { ...mdastNode.attributes } as Record<
+                string,
+                string
+              >;
+              if (newContentWidth) {
+                attrs['contentWidth'] = newContentWidth;
+              } else {
+                delete attrs['contentWidth'];
+              }
+              lexicalNode.setMdastNode({ ...mdastNode, attributes: attrs });
+            },
+            { discrete: true },
+          );
         }}
       />
 

--- a/packages/ui/src/lib/cmi5/mdx/plugins/quotes/QuotesContainerEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/quotes/QuotesContainerEditor.tsx
@@ -18,7 +18,14 @@ import {
 import { editorInPlayback$ } from '../../state/vars';
 import { parseStyleString } from '../../../markdown/MarkDownParser';
 
-import { alpha, Box, IconButton, SxProps, Tooltip, useTheme } from '@mui/material';
+import {
+  alpha,
+  Box,
+  IconButton,
+  SxProps,
+  Tooltip,
+  useTheme,
+} from '@mui/material';
 
 import DeleteIconButton from '../../components/DeleteIconButton';
 import EditIcon from '@mui/icons-material/Edit';
@@ -38,8 +45,7 @@ import { findMatchingQuotePreset } from './methods';
 import { QuotesContextProvider } from './QuotesContext';
 import { useFocusWithin } from '../shared/useFocusWithin';
 import QuotesSettings from './QuotesSettings';
-import { useBackgroundColors } from 'packages/ui/src/lib/hooks/useBackgroundColors';
-import { BackgroundColorTrigger } from 'packages/ui/src/lib/colors/BackgroundColorTrigger';
+import { BackgroundColorTrigger, useBackgroundColors } from '@rapid-cmi5/ui';
 
 /**
  * Quotes Container Editor for grid layout directive.
@@ -79,12 +85,12 @@ export const QuotesContainerEditor: React.FC<
   // Outer box: full-width background color band when backgroundColor is set.
   const outerSx: SxProps = backgroundColor
     ? {
-      boxShadow: `0 0 0 100vmax ${backgroundColor}`,
-      clipPath: `inset(0 -100vmax 0)`,
-      backgroundColor,
-      paddingTop: blockPadding,
-      paddingBottom: blockPadding,
-    }
+        boxShadow: `0 0 0 100vmax ${backgroundColor}`,
+        clipPath: `inset(0 -100vmax 0)`,
+        backgroundColor,
+        paddingTop: blockPadding,
+        paddingBottom: blockPadding,
+      }
     : {};
   //#endregion
 
@@ -94,7 +100,7 @@ export const QuotesContainerEditor: React.FC<
   const currentPreset = useMemo(() => {
     return mdastNode?.attributes?.preset
       ? findMatchingQuotePreset(mdastNode?.attributes?.preset) ||
-      QUOTE_PRESETS[0]
+          QUOTE_PRESETS[0]
       : QUOTE_PRESETS[0];
   }, [mdastNode?.attributes?.preset]);
 
@@ -144,9 +150,9 @@ export const QuotesContainerEditor: React.FC<
         children: mdastNode.children.map((child, i) =>
           i === carouselIndex
             ? {
-              ...child,
-              attributes: { ...child.attributes, avatar: newAvatar },
-            }
+                ...child,
+                attributes: { ...child.attributes, avatar: newAvatar },
+              }
             : child,
         ) as any,
       });
@@ -223,7 +229,13 @@ export const QuotesContainerEditor: React.FC<
             paddingTop: blockPadding,
             paddingBottom: blockPadding,
           }}
-        ><Box sx={{ backgroundColor: (theme) => `${alpha(theme.palette.background.default, muiTheme.palette.mode === 'light' ? 0 : 0.50)}`, }}>
+        >
+          <Box
+            sx={{
+              backgroundColor: (theme) =>
+                `${alpha(theme.palette.background.default, muiTheme.palette.mode === 'light' ? 0 : 0.5)}`,
+            }}
+          >
             <QuotesContextProvider
               carouselIndex={carouselIndex}
               preset={currentPreset.id}
@@ -260,7 +272,9 @@ export const QuotesContainerEditor: React.FC<
               </IconButton>
             </Tooltip>
             <BackgroundColorTrigger
-              currentColor={backgroundColor ? { color: pendingColor } : undefined}
+              currentColor={
+                backgroundColor ? { color: pendingColor } : undefined
+              }
               onTrigger={openPicker}
             />
             <InsertLineReturnButton

--- a/packages/ui/src/lib/cmi5/mdx/plugins/shared/useGutterRight.ts
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/shared/useGutterRight.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { resolveLessonThemeCSS } from '../../../../styles/lessonThemeStyles';
 import { toolbarRect$ } from '../toolbar/vars';
 import { useSignalEffect } from '@preact/signals-react';
-import { useLessonStyles } from 'packages/ui/src/lib/hooks/useLessonStyles';
 
 type ResolvedThemeCSS = ReturnType<typeof resolveLessonThemeCSS>;
 
@@ -37,7 +36,6 @@ export const useGutterRight = (
   const calculateMenuRight = useCallback(() => {
     const appRight = toolbarRect$.value?.right;
     if (appRight == null || !containerRef.current) {
-
       return;
     }
     const containerRight = containerRef.current.getBoundingClientRect().right;

--- a/packages/ui/src/lib/cmi5/mdx/plugins/statements/StatementsContainerEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/statements/StatementsContainerEditor.tsx
@@ -37,8 +37,7 @@ import { findMatchingStatementPreset } from './methods';
 
 import { StatementsContextProvider } from './StatementsContext';
 import StatementsSettings from './StatementsSettings';
-import { useBackgroundColors } from 'packages/ui/src/lib/hooks/useBackgroundColors';
-import { BackgroundColorTrigger } from 'packages/ui/src/lib/colors/BackgroundColorTrigger';
+import { BackgroundColorTrigger, useBackgroundColors } from '@rapid-cmi5/ui';
 
 /**
  * Statements Container Editor for the statements layout directive.
@@ -81,7 +80,7 @@ export const StatementsContainerEditor: React.FC<
   const currentPreset = useMemo(() => {
     return mdastNode?.attributes?.preset
       ? findMatchingStatementPreset(mdastNode?.attributes?.preset) ||
-      STATEMENT_PRESETS[0]
+          STATEMENT_PRESETS[0]
       : STATEMENT_PRESETS[0];
   }, [mdastNode?.attributes?.preset]);
 
@@ -101,7 +100,6 @@ export const StatementsContainerEditor: React.FC<
     }
     return undefined;
   }, [mdastNode.children[0].attributes.avatar]);
-
 
   /**
    * Reverts changes and closes modal
@@ -134,7 +132,6 @@ export const StatementsContainerEditor: React.FC<
 
       await new Promise((resolve) => setTimeout(resolve, 500));
       setSelectedPreset(newPreset);
-
     },
     [mdastNode, updateMdastNode, carouselIndex],
   );
@@ -183,12 +180,12 @@ export const StatementsContainerEditor: React.FC<
 
   const outerSx: SxProps = backgroundColor
     ? {
-      boxShadow: `0 0 0 100vmax ${backgroundColor}`,
-      clipPath: `inset(0 -100vmax 0)`,
-      backgroundColor,
-      paddingTop: blockPadding,
-      paddingBottom: blockPadding,
-    }
+        boxShadow: `0 0 0 100vmax ${backgroundColor}`,
+        clipPath: `inset(0 -100vmax 0)`,
+        backgroundColor,
+        paddingTop: blockPadding,
+        paddingBottom: blockPadding,
+      }
     : {};
 
   return (
@@ -209,8 +206,9 @@ export const StatementsContainerEditor: React.FC<
         <Box
           sx={{
             width: '100%',
-            boxShadow: selectedPreset.id === "3" ? 2 : undefined,
-            backgroundColor: (theme) => `${selectedPreset.id === "3" ? theme.palette.background.paper : "transparent"}`,
+            boxShadow: selectedPreset.id === '3' ? 2 : undefined,
+            backgroundColor: (theme) =>
+              `${selectedPreset.id === '3' ? theme.palette.background.paper : 'transparent'}`,
             paddingTop: blockPadding,
             paddingBottom: blockPadding,
           }}
@@ -236,7 +234,6 @@ export const StatementsContainerEditor: React.FC<
         {/* Gutter buttons */}
         {!isPlayback && (
           <Box
-
             sx={{
               backgroundColor:
                 muiTheme.palette.mode === 'dark' ? '#282b30e6' : '#EEEEEEe6',
@@ -246,14 +243,15 @@ export const StatementsContainerEditor: React.FC<
               right: menuRight,
             }}
           >
-
             <Tooltip title="Edit Statement Layout">
               <IconButton onClick={handleConfigure}>
                 <EditIcon />
               </IconButton>
             </Tooltip>
             <BackgroundColorTrigger
-              currentColor={backgroundColor ? { color: pendingColor } : undefined}
+              currentColor={
+                backgroundColor ? { color: pendingColor } : undefined
+              }
               onTrigger={openPicker}
             />
             <InsertLineReturnButton
@@ -306,7 +304,7 @@ export const StatementsContainerEditor: React.FC<
         palette={SHAPE_PRESET_COLORS}
         onPickColor={(color) => {
           pendingColorRef.current = color;
-           setPendingColorAndRef(color);
+          setPendingColorAndRef(color);
         }}
         onClear={handleClearColor}
         noneLabel="No background"

--- a/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
@@ -10,8 +10,14 @@ import * as Mdast from 'mdast';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import type { BlockContent, DefinitionContent } from 'mdast';
 import { ContainerDirective } from 'mdast-util-directive';
-import { CSSProperties, useCallback, useContext, useEffect, useRef, useState } from 'react';
-
+import {
+  CSSProperties,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   Box,
@@ -45,7 +51,6 @@ import { TextFieldMainUi } from '../../../../inputs/textfields/textfields';
 import { StepsContext } from './StepsContext';
 import { StepContentDirectiveNode, StepDirectiveNode } from './types';
 
-
 import { DEFAULT_STEP } from './constants';
 import ModalDialog from '../../../../modals/ModalDialog';
 import {
@@ -55,9 +60,7 @@ import {
 } from '../../../../utility/buttons';
 import { parseStyleString } from '../../../markdown/MarkDownParser';
 import { editorInPlayback$ } from '../../state/vars';
-import {
-  convertMdastToMarkdown,
-} from '../../util/conversion';
+import { convertMdastToMarkdown } from '../../util/conversion';
 import { LessonThemeContext } from '../../contexts/LessonThemeContext';
 import {
   resolveLessonThemeCSS,
@@ -68,8 +71,7 @@ import { SHAPE_PRESET_COLORS } from '../../constants/colors';
 import { BlockAppearanceForm } from '../shared/BlockAppearanceForm';
 import { useGutterRight } from '../shared/useGutterRight';
 import { ContentWidthEnum } from '@rapid-cmi5/cmi5-build-common';
-import { useBackgroundColors } from 'packages/ui/src/lib/hooks/useBackgroundColors';
-import { BackgroundColorTrigger } from 'packages/ui/src/lib/colors/BackgroundColorTrigger';
+import { BackgroundColorTrigger, useBackgroundColors } from '@rapid-cmi5/ui';
 
 /**
  * Steps Editor for steps directive
@@ -408,12 +410,12 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
 
   const outerSx: SxProps = backgroundColor
     ? {
-      boxShadow: `0 0 0 100vmax ${backgroundColor}`,
-      clipPath: `inset(0 -100vmax 0)`,
-      backgroundColor,
-      paddingTop: blockPadding,
-      paddingBottom: blockPadding,
-    }
+        boxShadow: `0 0 0 100vmax ${backgroundColor}`,
+        clipPath: `inset(0 -100vmax 0)`,
+        backgroundColor,
+        paddingTop: blockPadding,
+        paddingBottom: blockPadding,
+      }
     : {};
 
   /**
@@ -424,8 +426,16 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
       <Box
         ref={containerRef}
         {...(backgroundColor ? { 'data-bgcolor': 'true' } : {})}
-        {...(contentWidth !== undefined ? { 'data-block-override': 'true' } : {})}
-        {...(contentWidth !== undefined ? { style: { '--block-max-width': blockMaxWidth ?? 'none' } as CSSProperties } : {})}
+        {...(contentWidth !== undefined
+          ? { 'data-block-override': 'true' }
+          : {})}
+        {...(contentWidth !== undefined
+          ? {
+              style: {
+                '--block-max-width': blockMaxWidth ?? 'none',
+              } as CSSProperties,
+            }
+          : {})}
         sx={{
           padding: 0,
           position: 'relative',
@@ -433,10 +443,10 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
           ...sxProps,
           ...(blockMaxWidth
             ? {
-              maxWidth: blockMaxWidth,
-              marginLeft: 'auto',
-              marginRight: 'auto',
-            }
+                maxWidth: blockMaxWidth,
+                marginLeft: 'auto',
+                marginRight: 'auto',
+              }
             : {}),
           marginTop: 0,
           marginBottom: 0,
@@ -482,7 +492,6 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
               <div>
                 {!isPlayback && (
                   <Box
-
                     sx={{
                       backgroundColor:
                         muiTheme.palette.mode === 'dark'
@@ -494,8 +503,6 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
                       right: menuRight,
                     }}
                   >
-
-
                     <Tooltip title="Edit Steps Settings">
                       <IconButton onClick={handleConfigure}>
                         <EditIcon />
@@ -510,7 +517,9 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
                       </IconButton>
                     </Tooltip>
                     <BackgroundColorTrigger
-                      currentColor={backgroundColor ? { color: pendingColor } : undefined}
+                      currentColor={
+                        backgroundColor ? { color: pendingColor } : undefined
+                      }
                       onTrigger={openPicker}
                     />
                     <InsertLineReturnButton

--- a/packages/ui/src/lib/cmi5/mdx/plugins/tabs/TabsEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/tabs/TabsEditor.tsx
@@ -72,8 +72,7 @@ import { getDirectiveBlockShadow } from '../../../../styles/directiveStyles';
 import { ColorSelectionPopover } from '../../../../colors/ColorSelectionPopover';
 import { SHAPE_PRESET_COLORS } from '../../constants/colors';
 import { DIRECTIVE_INNER_BOX_SHADOW } from '../../constants/directiveLayout';
-import { useBackgroundColors } from 'packages/ui/src/lib/hooks/useBackgroundColors';
-import { BackgroundColorTrigger } from 'packages/ui/src/lib/colors/BackgroundColorTrigger';
+import { BackgroundColorTrigger, useBackgroundColors } from '@rapid-cmi5/ui';
 
 /**
  * Tabs Editor for tabs directive
@@ -372,12 +371,12 @@ export const TabsEditor: React.FC<DirectiveEditorProps<TabDirectiveNode>> = ({
   // trailing <p>'s margin-top so the band fills flush to the next block.
   const outerSx: SxProps = backgroundColor
     ? {
-      boxShadow: `0 0 0 100vmax ${backgroundColor}`,
-      clipPath: `inset(0 -100vmax 0)`,
-      backgroundColor,
-      paddingTop: blockPadding,
-      paddingBottom: blockPadding,
-    }
+        boxShadow: `0 0 0 100vmax ${backgroundColor}`,
+        clipPath: `inset(0 -100vmax 0)`,
+        backgroundColor,
+        paddingTop: blockPadding,
+        paddingBottom: blockPadding,
+      }
     : {};
 
   // Inner box: fills all available width (lesson content width applies to text
@@ -390,14 +389,14 @@ export const TabsEditor: React.FC<DirectiveEditorProps<TabDirectiveNode>> = ({
     : {};
   const innerSx: SxProps = backgroundColor
     ? {
-      backgroundColor: muiTheme.palette.background.paper,
-      boxShadow: DIRECTIVE_INNER_BOX_SHADOW,
-      ...widthOverrideSx,
-    }
+        backgroundColor: muiTheme.palette.background.paper,
+        boxShadow: DIRECTIVE_INNER_BOX_SHADOW,
+        ...widthOverrideSx,
+      }
     : {
-      boxShadow: dropShadow,
-      ...widthOverrideSx,
-    };
+        boxShadow: dropShadow,
+        ...widthOverrideSx,
+      };
 
   /**
    * Render Tabs and Nested Content
@@ -412,10 +411,10 @@ export const TabsEditor: React.FC<DirectiveEditorProps<TabDirectiveNode>> = ({
           : {})}
         {...(contentWidth !== undefined
           ? {
-            style: {
-              '--block-max-width': blockMaxWidth ?? 'none',
-            } as CSSProperties,
-          }
+              style: {
+                '--block-max-width': blockMaxWidth ?? 'none',
+              } as CSSProperties,
+            }
           : {})}
         sx={{
           padding: 0,
@@ -505,7 +504,9 @@ export const TabsEditor: React.FC<DirectiveEditorProps<TabDirectiveNode>> = ({
               </IconButton>
             </Tooltip>
             <BackgroundColorTrigger
-              currentColor={backgroundColor ? { color: pendingColor } : undefined}
+              currentColor={
+                backgroundColor ? { color: pendingColor } : undefined
+              }
               onTrigger={openPicker}
             />
             <InsertLineReturnButton


### PR DESCRIPTION
These imports are breaking the npm package as the root level path cannot be used in npm packages.
Imports must be either relative or to another package via @rapid-cmi5/<package>
Also corrected the paths for eslint files in packages.

Please download the eslint extension in order to be auto warned about these incorrect paths. 
If you already had it installed it should work now with the corrected eslint paths.

No ticket associated with fix, very easy changes to get rangeos nx npm upgrade working