### PR TITLE
feat: fix for copy pasted blocks within anim blocks

### DIFF
--- a/packages/ui/src/lib/cmi5/mdx/editors/AnimDirectiveDescriptor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/editors/AnimDirectiveDescriptor.tsx
@@ -13,6 +13,7 @@ import {
   insertMarkdown$,
   $isFrontmatterNode,
 } from '@mdxeditor/editor';
+import { RC5NestedLexicalEditor } from '../plugins/shared/RC5NestedLexicalEditor';
 import { useEffect, useRef, useState, useCallback } from 'react';
 import {
   $createParagraphNode,
@@ -331,7 +332,7 @@ export const AnimDirectiveDescriptor: DirectiveDescriptor<ContainerDirective> =
 
             {/* Nested content */}
             <Box sx={{ flex: 1 }}>
-              <NestedLexicalEditor<ContainerDirective>
+              <RC5NestedLexicalEditor<ContainerDirective>
                 block={true}
                 getContent={(node) => node.children}
                 getUpdatedMdastNode={(mdastNode, children: any) => ({


### PR DESCRIPTION
NestedLexicalEditor hardcodes namespace: "NestedEditor" , which mismatches the root editor's "MDXEditor" namespace, causing Lexical's paste handler to reject the application/x-lexical-editor blob and fall back to plain HTML. RC5NestedLexicalEditor omits the namespace so Lexical inherits it from the parent, namespaces match, and paste preserves formatting.

<img width="2183" height="1022" alt="animpaste" src="https://github.com/user-attachments/assets/09941f5b-4f08-45d4-a8e8-e0d17f50c904" />
