### PR TITLE
feat: Added in the ability to launch a real cmi5 link and scenario

### DIFF
--- a/apps/rapid-cmi5-electron-frontend/src/app/RapidCmi5Wrapper.tsx
+++ b/apps/rapid-cmi5-electron-frontend/src/app/RapidCmi5Wrapper.tsx
@@ -35,6 +35,7 @@ export function RapidCmi5Wrapper() {
     fetchScenario: webFetchScenario,
     processAu: webProcessAu,
     listScenarios: webListScenarios,
+    createAuMapping: webCreateAuMapping,
   } = useScenarioApi(rangeURL, token);
 
   const fetchScenario = useMemo(() => {
@@ -95,6 +96,7 @@ export function RapidCmi5Wrapper() {
         return response;
       }}
       processAu={processAu}
+      createAuMapping={webCreateAuMapping}
       fetchScenario={fetchScenario}
       GetScenariosForm={
         listScenarios

--- a/packages/common/src/lib/apis/hooks/useScenarioApi.ts
+++ b/packages/common/src/lib/apis/hooks/useScenarioApi.ts
@@ -6,8 +6,9 @@ import {
   ScenarioQuery,
   PaginatedScenariosResponse,
 } from '../scenarioContract';
-import { CourseAU } from '@rapid-cmi5/cmi5-build-common';
+import { CourseAU } from '../../types/course';
 import {
+  handleCreateAuMapping,
   handleFetchScenario,
   handleListScenarios,
   handleProcessAu,
@@ -51,9 +52,18 @@ export function useScenarioApi(url?: string, token?: string) {
     [apiClient],
   );
 
+  const creatAuMappingCb = useCallback(
+    async (auId: string, scenarioUUID: string): Promise<void> => {
+      if (!apiClient) throw new Error('API client is not set');
+      return await handleCreateAuMapping(auId, scenarioUUID, apiClient);
+    },
+    [apiClient],
+  );
+
   const fetchScenario = apiClient ? fetchScenarioCb : undefined;
   const listScenarios = apiClient ? listScenariosCb : undefined;
   const processAu = apiClient ? processAuCb : undefined;
+  const createAuMapping = apiClient ? creatAuMappingCb : undefined;
 
-  return { fetchScenario, listScenarios, processAu };
+  return { fetchScenario, listScenarios, processAu, createAuMapping };
 }

--- a/packages/common/src/lib/apis/utils/scenario.ts
+++ b/packages/common/src/lib/apis/utils/scenario.ts
@@ -69,19 +69,13 @@ export const handleListScenarios = async (
   }
   throw new Error(`Failed to list scenarios (status: ${response.status})`);
 };
-
-export const handleProcessAu = async (
-  au: CourseAU,
-  blockId: string,
+export const handleCreateAuMapping = async (
+  auId: string,
+  scenarioUUID: string,
   apiClient: ScenarioClient,
 ) => {
-  const scenarioUUID = await handleGetAuScenarioUUID(au, apiClient);
-  if (!scenarioUUID) return;
-
-  const auId = generateAuId({ blockId, auName: au.auName });
-  // ts-rest does not encodeURIComponent path params; auId can be a URL with
-  // slashes that would break server-side path routing if not encoded first.
   const encodedAuId = encodeURIComponent(auId);
+
   let existingMapping: Awaited<ReturnType<typeof apiClient.getAuMapping>>;
   try {
     existingMapping = await apiClient.getAuMapping({
@@ -115,4 +109,18 @@ export const handleProcessAu = async (
   } else {
     throw existingMapping.body;
   }
+};
+
+export const handleProcessAu = async (
+  au: CourseAU,
+  blockId: string,
+  apiClient: ScenarioClient,
+) => {
+  const scenarioUUID = await handleGetAuScenarioUUID(au, apiClient);
+  if (!scenarioUUID) return;
+
+  const auId = generateAuId({ blockId, auName: au.auName });
+  // ts-rest does not encodeURIComponent path params; auId can be a URL with
+  // slashes that would break server-side path routing if not encoded first.
+  return await handleCreateAuMapping(auId, scenarioUUID, apiClient);
 };

--- a/packages/common/src/lib/apis/utils/scenario.ts
+++ b/packages/common/src/lib/apis/utils/scenario.ts
@@ -9,6 +9,10 @@ type ScenarioClient = InitClientReturn<
   { baseUrl: string }
 >;
 
+/**
+ * Resolves a scenario UUID for an AU by UUID first, then by name.
+ * Throws if the configured UUID/name does not exist; returns null if neither is set.
+ */
 export const handleGetAuScenarioUUID = async (
   au: CourseAU,
   apiClient: ScenarioClient,
@@ -46,6 +50,9 @@ export const handleGetAuScenarioUUID = async (
   return null;
 };
 
+/**
+ * Fetches a single scenario by UUID. Throws on non-200 responses.
+ */
 export const handleFetchScenario = async (
   uuid: string,
   apiClient: ScenarioClient,
@@ -59,6 +66,9 @@ export const handleFetchScenario = async (
   );
 };
 
+/**
+ * Lists scenarios matching the given query. Throws on non-200 responses.
+ */
 export const handleListScenarios = async (
   query: ScenarioQuery,
   apiClient: ScenarioClient,
@@ -69,11 +79,17 @@ export const handleListScenarios = async (
   }
   throw new Error(`Failed to list scenarios (status: ${response.status})`);
 };
+/**
+ * Upserts an AU-to-scenario mapping: updates the existing mapping if one exists,
+ * otherwise creates a new one. Throws if the mapping cannot be created or updated.
+ */
 export const handleCreateAuMapping = async (
   auId: string,
   scenarioUUID: string,
   apiClient: ScenarioClient,
 ) => {
+  // ts-rest does not encodeURIComponent path params; auId can be a URL with
+  // slashes that would break server-side path routing if not encoded first.
   const encodedAuId = encodeURIComponent(auId);
 
   let existingMapping: Awaited<ReturnType<typeof apiClient.getAuMapping>>;
@@ -111,6 +127,10 @@ export const handleCreateAuMapping = async (
   }
 };
 
+/**
+ * Resolves the AU's scenario and upserts its mapping. No-ops when the AU has
+ * no configured scenario UUID or name.
+ */
 export const handleProcessAu = async (
   au: CourseAU,
   blockId: string,
@@ -120,7 +140,5 @@ export const handleProcessAu = async (
   if (!scenarioUUID) return;
 
   const auId = generateAuId({ blockId, auName: au.auName });
-  // ts-rest does not encodeURIComponent path params; auId can be a URL with
-  // slashes that would break server-side path routing if not encoded first.
   return await handleCreateAuMapping(auId, scenarioUUID, apiClient);
 };

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/GitViewer/session/RapidCmi5OptsContext.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/GitViewer/session/RapidCmi5OptsContext.tsx
@@ -73,6 +73,7 @@ export interface RapidCmi5Opts {
   userAuth?: UserAuth;
   downloadCmi5Player?: () => Promise<any>;
   processAu?: (au: CourseAU, blockId: string) => Promise<void>;
+  createAuMapping?: (auId: string, scenerioUUID: string) => Promise<void>;
   GetScenariosForm?: React.ComponentType<GetScenarioFormProps>;
   fetchScenario?: (uuid: string) => Promise<ScenarioApi>;
   QuizBankSearchModal?: React.ComponentType<GetQuizBankSearchModalProps>;

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/TestInPlayerDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/TestInPlayerDialog.tsx
@@ -16,7 +16,7 @@ import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { useSelector, useDispatch } from 'react-redux';
 import { useContext, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { debugLogError, FormCrudType, modal, setModal } from '@rapid-cmi5/ui';
+import { FormCrudType, modal, setModal } from '@rapid-cmi5/ui';
 import { ScenarioApi } from '@rapid-cmi5/cmi5-build-common';
 import {
   courseDataCache,
@@ -26,41 +26,17 @@ import {
 import { currentRepoAccessObjectSel } from '../../../../../redux/repoManagerReducer';
 import { testInPlayerModalId } from '../../../../rapidcmi5_mdx/modals/constants';
 import { ModalDialog } from '@rapid-cmi5/ui';
-import { getFsInstance } from '../../../GitViewer/utils/gitFsInstance';
 import { GitContext } from '../../../GitViewer/session/GitContext';
 import { useRapidCmi5Opts } from '../../../GitViewer/session/RapidCmi5OptsContext';
 import {
-  fetchLaunchUrl,
-  randomUuid,
-  rewriteLaunchHost,
-  fetchFirstAuId,
-} from './cmi5LaunchLinks';
-import { writeConfigViaIpc, writeConfigViaHttp } from './writeConfig';
+  DEFAULT_ACTOR_HOMEPAGE,
+  DEFAULT_RETURN_URL,
+  useLaunchInPlayer,
+} from './useLaunchInPlayer';
 
 const DEFAULT_PLAYER_URL = 'http://localhost:4201';
 // Electron IPC fallback: path relative to repo root
 const DEFAULT_CONFIG_PATH = 'apps/cc-cmi5-player/src/test/config.json';
-
-async function loadLessonViaZip(
-  playerUrl: string,
-  zipBlob: Blob,
-  lessonDirPath: string,
-): Promise<void> {
-  const endpoint = `${playerUrl.replace(/\/$/, '')}/upload-lesson-zip?lessonDirPath=${encodeURIComponent(lessonDirPath)}`;
-  const res = await fetch(endpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/octet-stream' },
-    body: zipBlob,
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    throw new Error(`Player dev server responded ${res.status}: ${text}`);
-  }
-  const json = await res.json().catch(() => ({ success: false }));
-  if (!json.success) {
-    throw new Error(json.error ?? 'Player dev server returned success:false');
-  }
-}
 
 const ENV_LMS_API_BASE = process.env['NX_PUBLIC_CPT_PLAYER_URL'];
 const ENV_LMS_COURSE_ID = process.env['NX_PUBLIC_CPT_COURSE_ID'];
@@ -68,8 +44,6 @@ const ENV_LMS_TOKEN = process.env['NX_PUBLIC_CPT_TOKEN'];
 
 const DEFAULT_LMS_API_BASE =
   ENV_LMS_API_BASE || 'https://cpt-player.develop-cp.rangeos.engineering';
-const DEFAULT_ACTOR_HOMEPAGE = 'https://moodle.com';
-const DEFAULT_RETURN_URL = 'https://lms.example.com/return';
 
 export function TestInPlayerDialog() {
   const dispatch = useDispatch();
@@ -98,9 +72,8 @@ export function TestInPlayerDialog() {
   const [selectedScenario, setSelectedScenario] = useState<ScenarioApi | null>(
     null,
   );
-  const [isLoading, setIsLoading] = useState(false);
-  const [statusMsg, setStatusMsg] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+
+  const { launch, isLoading, statusMsg, error, reset } = useLaunchInPlayer();
 
   const selectedBlock = courseData?.blocks?.[currentBlockIndex];
   const currentLesson = selectedBlock?.aus?.[currentAuIndex];
@@ -109,121 +82,32 @@ export function TestInPlayerDialog() {
     actorName || userAuth?.userName || userAuth?.userEmail || '';
 
   const handleClose = () => {
-    setError(null);
-    setStatusMsg(null);
+    reset();
     dispatch(setModal({ type: '', id: null, name: null }));
   };
 
-  const handleLaunch = async () => {
-    if (!currentLesson) {
-      setError('No lesson selected.');
-      return;
-    }
-
-    setIsLoading(true);
-    setError(null);
-    setStatusMsg(null);
-
-    try {
-      const fsInstance = getFsInstance();
-
-      if (hasIpc) {
-        // Electron: write config via IPC (no assets in this path)
-        const auJson = JSON.stringify(currentLesson, null, 2);
-        await writeConfigViaIpc(auJson, playerUrl, configPath);
-      } else if (repoAccessObject && currentCourse?.basePath) {
-        // Browser: build zip in-memory, ship to player dev server (includes assets)
-        if (rebuildPlayerZip && downloadCmi5Player) {
-          setStatusMsg('Downloading player zip…');
-          await fsInstance.downloadCmi5PlayerIfNeeded(downloadCmi5Player);
-        } else {
-          setStatusMsg('Seeding player cache from dev server…');
-          await fsInstance.seedPlayerCacheFromDevServer(playerUrl);
-        }
-
-        setStatusMsg('Building course zip…');
-
-        // dirPath on the AU is relative (e.g. "sandbox/intro")
-        const lessonDirPath = `compiled_course/blocks/${currentLesson.dirPath}`;
-
-        const zipBlob = await fsInstance.buildCmi5CourseBlob(
-          repoAccessObject,
-          currentCourse.basePath,
-        );
-
-        setStatusMsg('Uploading to player…');
-        await loadLessonViaZip(playerUrl, zipBlob, lessonDirPath);
-      } else {
-        // Fallback: content-only (no assets)
-        const auJson = JSON.stringify(currentLesson, null, 2);
-        await writeConfigViaHttp(playerUrl, auJson);
-      }
-
-      if (useRealLaunchLink) {
-        if (!lmsToken.trim()) {
-          setError('LMS bearer token is required for real launch link.');
-          return;
-        }
-        if (!lmsCourseId.trim()) {
-          setError('LMS course ID is required for real launch link.');
-          return;
-        }
-        if (!resolvedActorName.trim()) {
-          setError('Actor name is required for real launch link.');
-          return;
-        }
-
-        setIsLoading(true);
-        setError(null);
-        setStatusMsg('Requesting launch URL from LMS…');
-        try {
-          const launchUrl = await fetchLaunchUrl({
-            lmsApiBase,
-            courseId: lmsCourseId.trim(),
-            auIndex: currentAuIndex,
-            token: lmsToken.trim(),
-            actorName: resolvedActorName.trim(),
-            actorHomePage: actorHomePage.trim() || DEFAULT_ACTOR_HOMEPAGE,
-            registration: randomUuid(),
-            returnUrl: returnUrl.trim() || DEFAULT_RETURN_URL,
-          });
-          const localUrl = rewriteLaunchHost(launchUrl, playerUrl);
-
-          // Associate the selected scenario with the first AU before opening
-          if (selectedScenario && createAuMapping) {
-            setStatusMsg('Mapping scenario to AU…');
-            try {
-              const auId = await fetchFirstAuId({
-                lmsApiBase,
-                courseId: lmsCourseId.trim(),
-                token: lmsToken.trim(),
-              });
-              await createAuMapping(auId, selectedScenario.uuid);
-            } catch (err: unknown) {
-              debugLogError(err instanceof Error ? err.message : String(err));
-            }
-          }
-
-          window.open(localUrl, '_blank');
-          handleClose();
-        } catch (err: any) {
-          setError(err?.message ?? String(err));
-        } finally {
-          setIsLoading(false);
-          setStatusMsg(null);
-        }
-        return;
-      }
-
-      window.open(playerUrl, '_blank');
-      handleClose();
-    } catch (err: any) {
-      setError(err?.message ?? String(err));
-    } finally {
-      setIsLoading(false);
-      setStatusMsg(null);
-    }
-  };
+  const handleLaunch = () =>
+    launch({
+      currentLesson,
+      hasIpc,
+      playerUrl,
+      configPath,
+      rebuildPlayerZip,
+      repoAccessObject,
+      currentCourse,
+      downloadCmi5Player,
+      useRealLaunchLink,
+      lmsApiBase,
+      lmsCourseId,
+      lmsToken,
+      resolvedActorName,
+      actorHomePage,
+      returnUrl,
+      currentAuIndex,
+      selectedScenario,
+      createAuMapping,
+      onSuccess: handleClose,
+    });
 
   const lessonLabel = currentLesson
     ? `${selectedBlock?.blockName ?? ''} / ${currentLesson.auName}`

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/TestInPlayerDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/TestInPlayerDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  Divider,
   FormControlLabel,
   Switch,
   TextField,
@@ -14,17 +15,27 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { useSelector, useDispatch } from 'react-redux';
 import { useContext, useState } from 'react';
-import { modal, setModal } from '@rapid-cmi5/ui';
+import { useForm } from 'react-hook-form';
+import { debugLogError, FormCrudType, modal, setModal } from '@rapid-cmi5/ui';
+import { ScenarioApi } from '@rapid-cmi5/cmi5-build-common';
 import {
   courseDataCache,
   currentAu,
   currentBlock,
-} from '../../../../redux/courseBuilderReducer';
-import { currentRepoAccessObjectSel } from '../../../../redux/repoManagerReducer';
-import { testInPlayerModalId } from '../../../rapidcmi5_mdx/modals/constants';
+} from '../../../../../redux/courseBuilderReducer';
+import { currentRepoAccessObjectSel } from '../../../../../redux/repoManagerReducer';
+import { testInPlayerModalId } from '../../../../rapidcmi5_mdx/modals/constants';
 import { ModalDialog } from '@rapid-cmi5/ui';
-import { getFsInstance } from '../../GitViewer/utils/gitFsInstance';
-import { GitContext } from '../../GitViewer/session/GitContext';
+import { getFsInstance } from '../../../GitViewer/utils/gitFsInstance';
+import { GitContext } from '../../../GitViewer/session/GitContext';
+import { useRapidCmi5Opts } from '../../../GitViewer/session/RapidCmi5OptsContext';
+import {
+  fetchLaunchUrl,
+  randomUuid,
+  rewriteLaunchHost,
+  fetchFirstAuId,
+} from './cmi5LaunchLinks';
+import { writeConfigViaIpc, writeConfigViaHttp } from './writeConfig';
 
 const DEFAULT_PLAYER_URL = 'http://localhost:4201';
 // Electron IPC fallback: path relative to repo root
@@ -51,40 +62,14 @@ async function loadLessonViaZip(
   }
 }
 
-async function writeConfigViaHttp(
-  playerUrl: string,
-  auJson: string,
-): Promise<void> {
-  const endpoint = `${playerUrl.replace(/\/$/, '')}/test-config`;
-  const res = await fetch(endpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: auJson,
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    throw new Error(`Player dev server responded ${res.status}: ${text}`);
-  }
-  const json = await res.json().catch(() => ({ success: false }));
-  if (!json.success) {
-    throw new Error(json.error ?? 'Player dev server returned success:false');
-  }
-}
+const ENV_LMS_API_BASE = process.env['NX_PUBLIC_CPT_PLAYER_URL'];
+const ENV_LMS_COURSE_ID = process.env['NX_PUBLIC_CPT_COURSE_ID'];
+const ENV_LMS_TOKEN = process.env['NX_PUBLIC_CPT_TOKEN'];
 
-async function writeConfigViaIpc(
-  auJson: string,
-  playerUrl: string,
-  configPath: string,
-): Promise<void> {
-  const result = await (window as any).ipc.testInPlayer(
-    auJson,
-    playerUrl,
-    configPath,
-  );
-  if (!result?.success) {
-    throw new Error(result?.error ?? 'IPC call returned success:false');
-  }
-}
+const DEFAULT_LMS_API_BASE =
+  ENV_LMS_API_BASE || 'https://cpt-player.develop-cp.rangeos.engineering';
+const DEFAULT_ACTOR_HOMEPAGE = 'https://moodle.com';
+const DEFAULT_RETURN_URL = 'https://lms.example.com/return';
 
 export function TestInPlayerDialog() {
   const dispatch = useDispatch();
@@ -94,11 +79,25 @@ export function TestInPlayerDialog() {
   const courseData = useSelector(courseDataCache);
   const currentAuIndex = useSelector(currentAu);
   const currentBlockIndex = useSelector(currentBlock);
+  const { GetScenariosForm, userAuth, createAuMapping } = useRapidCmi5Opts();
+  const scenarioFormMethods = useForm();
 
   const [playerUrl, setPlayerUrl] = useState(DEFAULT_PLAYER_URL);
   const [configPath, setConfigPath] = useState(DEFAULT_CONFIG_PATH);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [rebuildPlayerZip, setRebuildPlayerZip] = useState(false);
+  const [useRealLaunchLink, setUseRealLaunchLink] = useState(false);
+  const [lmsApiBase, setLmsApiBase] = useState(DEFAULT_LMS_API_BASE);
+  const [lmsCourseId, setLmsCourseId] = useState(ENV_LMS_COURSE_ID ?? '');
+  const [lmsToken, setLmsToken] = useState(ENV_LMS_TOKEN ?? '');
+  const [actorName, setActorName] = useState(
+    () => userAuth?.userName || userAuth?.userEmail || '',
+  );
+  const [actorHomePage, setActorHomePage] = useState(DEFAULT_ACTOR_HOMEPAGE);
+  const [returnUrl, setReturnUrl] = useState(DEFAULT_RETURN_URL);
+  const [selectedScenario, setSelectedScenario] = useState<ScenarioApi | null>(
+    null,
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -106,6 +105,8 @@ export function TestInPlayerDialog() {
   const selectedBlock = courseData?.blocks?.[currentBlockIndex];
   const currentLesson = selectedBlock?.aus?.[currentAuIndex];
   const hasIpc = typeof (window as any).ipc?.testInPlayer === 'function';
+  const resolvedActorName =
+    actorName || userAuth?.userName || userAuth?.userEmail || '';
 
   const handleClose = () => {
     setError(null);
@@ -156,6 +157,62 @@ export function TestInPlayerDialog() {
         // Fallback: content-only (no assets)
         const auJson = JSON.stringify(currentLesson, null, 2);
         await writeConfigViaHttp(playerUrl, auJson);
+      }
+
+      if (useRealLaunchLink) {
+        if (!lmsToken.trim()) {
+          setError('LMS bearer token is required for real launch link.');
+          return;
+        }
+        if (!lmsCourseId.trim()) {
+          setError('LMS course ID is required for real launch link.');
+          return;
+        }
+        if (!resolvedActorName.trim()) {
+          setError('Actor name is required for real launch link.');
+          return;
+        }
+
+        setIsLoading(true);
+        setError(null);
+        setStatusMsg('Requesting launch URL from LMS…');
+        try {
+          const launchUrl = await fetchLaunchUrl({
+            lmsApiBase,
+            courseId: lmsCourseId.trim(),
+            auIndex: currentAuIndex,
+            token: lmsToken.trim(),
+            actorName: resolvedActorName.trim(),
+            actorHomePage: actorHomePage.trim() || DEFAULT_ACTOR_HOMEPAGE,
+            registration: randomUuid(),
+            returnUrl: returnUrl.trim() || DEFAULT_RETURN_URL,
+          });
+          const localUrl = rewriteLaunchHost(launchUrl, playerUrl);
+
+          // Associate the selected scenario with the first AU before opening
+          if (selectedScenario && createAuMapping) {
+            setStatusMsg('Mapping scenario to AU…');
+            try {
+              const auId = await fetchFirstAuId({
+                lmsApiBase,
+                courseId: lmsCourseId.trim(),
+                token: lmsToken.trim(),
+              });
+              await createAuMapping(auId, selectedScenario.uuid);
+            } catch (err: unknown) {
+              debugLogError(err instanceof Error ? err.message : String(err));
+            }
+          }
+
+          window.open(localUrl, '_blank');
+          handleClose();
+        } catch (err: any) {
+          setError(err?.message ?? String(err));
+        } finally {
+          setIsLoading(false);
+          setStatusMsg(null);
+        }
+        return;
       }
 
       window.open(playerUrl, '_blank');
@@ -290,6 +347,131 @@ export function TestInPlayerDialog() {
                   </Box>
                 }
               />
+
+              <Divider sx={{ my: 0.5 }} />
+
+              <FormControlLabel
+                control={
+                  <Switch
+                    size="small"
+                    checked={useRealLaunchLink}
+                    onChange={(e) => setUseRealLaunchLink(e.target.checked)}
+                  />
+                }
+                label={
+                  <Box>
+                    <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+                      Use real cmi5 launch link
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      display="block"
+                      color="text.secondary"
+                    >
+                      Requests a real launch URL from the LMS and opens it
+                      against the local player.
+                    </Typography>
+                  </Box>
+                }
+              />
+
+              {useRealLaunchLink && (
+                <Box
+                  sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}
+                >
+                  <TextField
+                    label="LMS API base URL"
+                    value={lmsApiBase}
+                    onChange={(e) => setLmsApiBase(e.target.value)}
+                    size="small"
+                    fullWidth
+                  />
+                  <TextField
+                    label="LMS course ID"
+                    value={lmsCourseId}
+                    onChange={(e) => setLmsCourseId(e.target.value)}
+                    size="small"
+                    fullWidth
+                    required
+                    helperText="Numeric course id (e.g. 1606)"
+                  />
+                  <TextField
+                    label="Bearer token"
+                    value={lmsToken}
+                    onChange={(e) => setLmsToken(e.target.value)}
+                    type="password"
+                    size="small"
+                    fullWidth
+                    required
+                    autoComplete="off"
+                  />
+                  <TextField
+                    label="Actor name"
+                    value={actorName}
+                    onChange={(e) => setActorName(e.target.value)}
+                    size="small"
+                    fullWidth
+                    placeholder={
+                      userAuth?.userName || userAuth?.userEmail || 'learner'
+                    }
+                    helperText="Defaults to signed-in user when blank"
+                  />
+                  <TextField
+                    label="Actor account home page"
+                    value={actorHomePage}
+                    onChange={(e) => setActorHomePage(e.target.value)}
+                    size="small"
+                    fullWidth
+                  />
+                  <TextField
+                    label="Return URL"
+                    value={returnUrl}
+                    onChange={(e) => setReturnUrl(e.target.value)}
+                    size="small"
+                    fullWidth
+                  />
+                  <Typography variant="caption" color="text.secondary">
+                    Launches AU index <code>{currentAuIndex}</code>. The host in
+                    the LMS response is rewritten to the Player URL above.
+                  </Typography>
+                </Box>
+              )}
+
+              {GetScenariosForm && useRealLaunchLink && (
+                <Box>
+                  <Typography
+                    variant="caption"
+                    display="block"
+                    sx={{ fontWeight: 'bold', mb: 0.5 }}
+                  >
+                    Scenario to launch with
+                  </Typography>
+                  <GetScenariosForm
+                    submitForm={(scenario: ScenarioApi) =>
+                      setSelectedScenario(scenario ?? null)
+                    }
+                    formType={FormCrudType.edit}
+                    errors={scenarioFormMethods.formState.errors}
+                    formMethods={scenarioFormMethods}
+                  />
+                  {selectedScenario && (
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        mt: 1,
+                        px: 1.5,
+                        py: 1,
+                        borderRadius: 1,
+                        bgcolor: 'action.hover',
+                        fontFamily: 'monospace',
+                        fontSize: '0.8rem',
+                      }}
+                    >
+                      {selectedScenario.name}
+                    </Typography>
+                  )}
+                </Box>
+              )}
             </Box>
           </Collapse>
 

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/cmi5LaunchLinks.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/cmi5LaunchLinks.ts
@@ -1,0 +1,92 @@
+export async function fetchFirstAuId(args: {
+  lmsApiBase: string;
+  courseId: string;
+  token: string;
+}): Promise<string> {
+  const { lmsApiBase, courseId, token } = args;
+  const endpoint = `${lmsApiBase.replace(/\/$/, '')}/api/v1/course/${encodeURIComponent(courseId)}`;
+  const res = await fetch(endpoint, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`LMS responded ${res.status}: ${text}`);
+  }
+  const json = await res.json();
+  const firstAu = json?.metadata?.aus[0];
+  const auId = firstAu?.id;
+  if (auId === undefined || auId === null) {
+    throw new Error('Course response did not include any AUs.');
+  }
+  return String(auId);
+}
+
+export function randomUuid(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  // RFC4122 v4 fallback
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+export function rewriteLaunchHost(
+  launchUrl: string,
+  playerUrl: string,
+): string {
+  const remote = new URL(launchUrl);
+  const local = new URL(playerUrl);
+  return `${local.origin}/index.html${remote.search}${remote.hash}`;
+}
+
+export async function fetchLaunchUrl(args: {
+  lmsApiBase: string;
+  courseId: string;
+  auIndex: number;
+  token: string;
+  actorName: string;
+  actorHomePage: string;
+  registration: string;
+  returnUrl: string;
+}): Promise<string> {
+  const {
+    lmsApiBase,
+    courseId,
+    auIndex,
+    token,
+    actorName,
+    actorHomePage,
+    registration,
+    returnUrl,
+  } = args;
+  const endpoint = `${lmsApiBase.replace(/\/$/, '')}/api/v1/course/${encodeURIComponent(courseId)}/launch-url/${auIndex}`;
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      actor: {
+        objectType: 'Agent',
+        account: { homePage: actorHomePage, name: actorName },
+      },
+      reg: registration,
+      returnUrl,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`LMS responded ${res.status}: ${text}`);
+  }
+  const json = await res.json();
+  if (!json?.url) {
+    throw new Error('LMS response did not include a launch url.');
+  }
+
+  return json.url as string;
+}

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/useLaunchInPlayer.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/useLaunchInPlayer.ts
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import { CourseAU, ScenarioApi } from '@rapid-cmi5/cmi5-build-common';
+import { debugLogError } from '@rapid-cmi5/ui';
+import {
+  fetchLaunchUrl,
+  randomUuid,
+  rewriteLaunchHost,
+  fetchFirstAuId,
+} from './cmi5LaunchLinks';
+import {
+  writeConfigViaIpc,
+  writeConfigViaHttp,
+  loadLessonViaZip,
+} from './writeConfig';
+import { getFsInstance } from '../../../GitViewer/utils/gitFsInstance';
+import type {
+  Course,
+  RepoAccessObject,
+} from '../../../../../redux/repoManagerReducer';
+
+export const DEFAULT_ACTOR_HOMEPAGE = 'https://moodle.com';
+export const DEFAULT_RETURN_URL = 'https://lms.example.com/return';
+
+export interface LaunchInPlayerOptions {
+  currentLesson: CourseAU | undefined;
+  hasIpc: boolean;
+  playerUrl: string;
+  configPath: string;
+  rebuildPlayerZip: boolean;
+  repoAccessObject: RepoAccessObject | null;
+  currentCourse: Course | null | undefined;
+  downloadCmi5Player?: () => Promise<unknown>;
+  useRealLaunchLink: boolean;
+  lmsApiBase: string;
+  lmsCourseId: string;
+  lmsToken: string;
+  resolvedActorName: string;
+  actorHomePage: string;
+  returnUrl: string;
+  currentAuIndex: number;
+  selectedScenario: ScenarioApi | null;
+  createAuMapping?: (auId: string, scenarioUUID: string) => Promise<void>;
+  onSuccess: () => void;
+}
+
+/**
+ * Orchestrates publishing the current lesson to the cmi5 player and (optionally)
+ * fetching a real LMS launch URL + mapping a scenario to the AU.
+ */
+export function useLaunchInPlayer() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setError(null);
+    setStatusMsg(null);
+  };
+
+  const launch = async (opts: LaunchInPlayerOptions) => {
+    const {
+      currentLesson,
+      hasIpc,
+      playerUrl,
+      configPath,
+      rebuildPlayerZip,
+      repoAccessObject,
+      currentCourse,
+      downloadCmi5Player,
+      useRealLaunchLink,
+      lmsApiBase,
+      lmsCourseId,
+      lmsToken,
+      resolvedActorName,
+      actorHomePage,
+      returnUrl,
+      currentAuIndex,
+      selectedScenario,
+      createAuMapping,
+      onSuccess,
+    } = opts;
+
+    if (!currentLesson) {
+      setError('No lesson selected.');
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setStatusMsg(null);
+
+    try {
+      const fsInstance = getFsInstance();
+
+      if (hasIpc) {
+        const auJson = JSON.stringify(currentLesson, null, 2);
+        await writeConfigViaIpc(auJson, playerUrl, configPath);
+      } else if (repoAccessObject && currentCourse?.basePath) {
+        if (rebuildPlayerZip && downloadCmi5Player) {
+          setStatusMsg('Downloading player zip…');
+          await fsInstance.downloadCmi5PlayerIfNeeded(downloadCmi5Player);
+        } else {
+          setStatusMsg('Seeding player cache from dev server…');
+          await fsInstance.seedPlayerCacheFromDevServer(playerUrl);
+        }
+
+        setStatusMsg('Building course zip…');
+        const lessonDirPath = `compiled_course/blocks/${currentLesson.dirPath}`;
+        const zipBlob = await fsInstance.buildCmi5CourseBlob(
+          repoAccessObject,
+          currentCourse.basePath,
+        );
+
+        setStatusMsg('Uploading to player…');
+        await loadLessonViaZip(playerUrl, zipBlob, lessonDirPath);
+      } else {
+        const auJson = JSON.stringify(currentLesson, null, 2);
+        await writeConfigViaHttp(playerUrl, auJson);
+      }
+
+      if (useRealLaunchLink) {
+        if (!lmsToken.trim()) {
+          setError('LMS bearer token is required for real launch link.');
+          return;
+        }
+        if (!lmsCourseId.trim()) {
+          setError('LMS course ID is required for real launch link.');
+          return;
+        }
+        if (!resolvedActorName.trim()) {
+          setError('Actor name is required for real launch link.');
+          return;
+        }
+
+        setStatusMsg('Requesting launch URL from LMS…');
+        const launchUrl = await fetchLaunchUrl({
+          lmsApiBase,
+          courseId: lmsCourseId.trim(),
+          auIndex: currentAuIndex,
+          token: lmsToken.trim(),
+          actorName: resolvedActorName.trim(),
+          actorHomePage: actorHomePage.trim() || DEFAULT_ACTOR_HOMEPAGE,
+          registration: randomUuid(),
+          returnUrl: returnUrl.trim() || DEFAULT_RETURN_URL,
+        });
+        const localUrl = rewriteLaunchHost(launchUrl, playerUrl);
+
+        if (selectedScenario && createAuMapping) {
+          setStatusMsg('Mapping scenario to AU…');
+          try {
+            const auId = await fetchFirstAuId({
+              lmsApiBase,
+              courseId: lmsCourseId.trim(),
+              token: lmsToken.trim(),
+            });
+            await createAuMapping(auId, selectedScenario.uuid);
+          } catch (err: unknown) {
+            debugLogError(err instanceof Error ? err.message : String(err));
+          }
+        }
+
+        window.open(localUrl, '_blank');
+        onSuccess();
+        return;
+      }
+
+      window.open(playerUrl, '_blank');
+      onSuccess();
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+    } finally {
+      setIsLoading(false);
+      setStatusMsg(null);
+    }
+  };
+
+  return { launch, isLoading, statusMsg, error, reset };
+}

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/writeConfig.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/writeConfig.ts
@@ -1,0 +1,34 @@
+export async function writeConfigViaHttp(
+  playerUrl: string,
+  auJson: string,
+): Promise<void> {
+  const endpoint = `${playerUrl.replace(/\/$/, '')}/test-config`;
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: auJson,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`Player dev server responded ${res.status}: ${text}`);
+  }
+  const json = await res.json().catch(() => ({ success: false }));
+  if (!json.success) {
+    throw new Error(json.error ?? 'Player dev server returned success:false');
+  }
+}
+
+export async function writeConfigViaIpc(
+  auJson: string,
+  playerUrl: string,
+  configPath: string,
+): Promise<void> {
+  const result = await (window as any).ipc.testInPlayer(
+    auJson,
+    playerUrl,
+    configPath,
+  );
+  if (!result?.success) {
+    throw new Error(result?.error ?? 'IPC call returned success:false');
+  }
+}

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/writeConfig.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/cmi5PlayerTests/writeConfig.ts
@@ -32,3 +32,24 @@ export async function writeConfigViaIpc(
     throw new Error(result?.error ?? 'IPC call returned success:false');
   }
 }
+
+export async function loadLessonViaZip(
+  playerUrl: string,
+  zipBlob: Blob,
+  lessonDirPath: string,
+): Promise<void> {
+  const endpoint = `${playerUrl.replace(/\/$/, '')}/upload-lesson-zip?lessonDirPath=${encodeURIComponent(lessonDirPath)}`;
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: zipBlob,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`Player dev server responded ${res.status}: ${text}`);
+  }
+  const json = await res.json().catch(() => ({ success: false }));
+  if (!json.success) {
+    throw new Error(json.error ?? 'Player dev server returned success:false');
+  }
+}

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/git/SelectGitDialogs.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/git/SelectGitDialogs.tsx
@@ -38,7 +38,7 @@ import CourseSelector from '../../selectors/CourseSelector';
 import CreateCourseForm from '../courses/CreateCourseForm';
 import CreateLessonForm from '../courses/CreateLessonForm';
 import DownloadCmi5ZipForm from '../courses/DownloadCmi5ZipForm';
-import TestInPlayerDialog from '../courses/TestInPlayerDialog';
+import TestInPlayerDialog from '../courses/cmi5PlayerTests/TestInPlayerDialog';
 import ImportRepoZipForm from '../courses/ImportRepoZipForm';
 import CloneRepoForm from './CloneRepoForm';
 import CommitForm from './CommitForm';


### PR DESCRIPTION
Added in a way to launch a real cmi5 link when testing cmi5 content from rapid cmi5 player.
1. You will use our current cmi5 player tester which is the rocket ship icon at the top write of visual designer.
2. You will then click on advanced and hit the 
Use real cmi5 launch link switch
3. Select scenario and enter in you username
4. Try selecting another course besides 1606 because we may end up over writing each others changes for scenarios

Gives an actual cmi5 and lrs connection.
Allows you to choose the scenario to test with.
Can set .env vars to not have to type in every time

NX_PUBLIC_CPT_PLAYER_URL=https://cpt-player.develop-cp.rangeos.engineering
NX_PUBLIC_CPT_COURSE_ID=1606
NX_PUBLIC_CPT_TOKEN=secret token

Ticket #CCUUI-2997
https://cybercents.atlassian.net/jira/software/c/projects/CCUI/boards/236?selectedIssue=CCUI-2997