### PR TITLE
fix: Slides no longer overwrite each other in raw markdown view

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/editors/RC5VisualEditor.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/editors/RC5VisualEditor.tsx
@@ -677,90 +677,82 @@ function RC5VisualEditor() {
    * UE injects markdown from lesson into editor and resets focus
    */
   useEffect(() => {
-    if (ref.current) {
-      if (typeof content !== 'string') {
-        debugLogError('Attempting to inject non string data into MdxEditor');
-        ref.current.setMarkdown('This slide data could not be presented ');
-      } else {
-        if (content !== ref.current.getMarkdown()) {
+    if (!ref.current) return;
+    if (typeof content !== 'string') {
+      debugLogError('Attempting to inject non string data into MdxEditor');
+      ref.current.setMarkdown('This slide data could not be presented ');
+      return;
+    }
+    if (content === ref.current.getMarkdown()) {
+      ref.current.focus();
+      return;
+    }
+    try {
+      debugLog('updateTeamScenario (load slide)');
+      const teamScenario =
+        content.indexOf(':consoles') > 0
+          ? { scenario: { uuid: 'unknown' } }
+          : { scenario: undefined };
+      dispatch(updateTeamScenario(teamScenario));
+
+      // Parse animations from frontmatter before setting markdown.
+      // If we already have unsaved animations in memory for this slide, keep them
+      // when the frontmatter is empty so navigating away/back does not drop them.
+      const parsedAnimations = parseAnimationsFromFrontmatter(content);
+      const existingAnimations =
+        slideAnimationsRef.current.get(currentSlideIndex) || [];
+
+      const shouldKeepExisting =
+        existingAnimations.length > 0 && parsedAnimations.length === 0;
+
+      const animationsToUse = shouldKeepExisting
+        ? existingAnimations
+        : parsedAnimations;
+
+      // Only update if animations actually changed to avoid unnecessary plugin rebuilds
+      const animationsChanged = !areAnimationsEqual(
+        existingAnimations,
+        animationsToUse,
+      );
+
+      if (animationsChanged) {
+        slideAnimationsRef.current.set(currentSlideIndex, animationsToUse);
+        setAnimationsVersion((v) => {
+          const newVersion = v + 1;
           debugLog(
-            'sees content !== ref.current.getMarkdown()',
+            `🔢 animationsVersion: ${v} → ${newVersion} (loading slide ${currentSlideIndex}, ${animationsToUse.length} animations, keepExisting=${shouldKeepExisting})`,
             undefined,
             undefined,
-            'editor',
+            'plugin',
           );
-          try {
-            debugLog('updateTeamScenario (load slide)');
-            const teamScenario =
-              content.indexOf(':consoles') > 0
-                ? { scenario: { uuid: 'unknown' } }
-                : { scenario: undefined };
-            dispatch(updateTeamScenario(teamScenario));
-
-            // Parse animations from frontmatter before setting markdown.
-            // If we already have unsaved animations in memory for this slide, keep them
-            // when the frontmatter is empty so navigating away/back does not drop them.
-            const parsedAnimations = parseAnimationsFromFrontmatter(content);
-            const existingAnimations =
-              slideAnimationsRef.current.get(currentSlideIndex) || [];
-
-            const shouldKeepExisting =
-              existingAnimations.length > 0 && parsedAnimations.length === 0;
-
-            const animationsToUse = shouldKeepExisting
-              ? existingAnimations
-              : parsedAnimations;
-
-            // Only update if animations actually changed to avoid unnecessary plugin rebuilds
-            const animationsChanged = !areAnimationsEqual(
-              existingAnimations,
-              animationsToUse,
-            );
-
-            if (animationsChanged) {
-              slideAnimationsRef.current.set(
-                currentSlideIndex,
-                animationsToUse,
-              );
-              setAnimationsVersion((v) => {
-                const newVersion = v + 1;
-                debugLog(
-                  `🔢 animationsVersion: ${v} → ${newVersion} (loading slide ${currentSlideIndex}, ${animationsToUse.length} animations, keepExisting=${shouldKeepExisting})`,
-                  undefined,
-                  undefined,
-                  'plugin',
-                );
-                return newVersion;
-              });
-            } else {
-              debugLog(
-                `⏭️ Skipping animationsVersion update - animations unchanged for slide ${currentSlideIndex}`,
-                undefined,
-                undefined,
-                'plugin',
-              );
-            }
-
-            debugLog(
-              `Loaded animations for slide ${currentSlideIndex}:`,
-              animationsToUse,
-            );
-            if (shouldKeepExisting) {
-              debugLog(
-                '↩️  Keeping in-memory animations because parsed frontmatter was empty',
-              );
-            }
-
-            debugLog('setting markdown to', content, undefined, 'editor');
-            ref.current.setMarkdown(content);
-          } catch (error: any) {
-            debugLog('Could not set markdown', error, undefined, 'editor');
-          }
-        }
+          return newVersion;
+        });
+      } else {
+        debugLog(
+          `⏭️ Skipping animationsVersion update - animations unchanged for slide ${currentSlideIndex}`,
+          undefined,
+          undefined,
+          'plugin',
+        );
       }
 
-      ref.current?.focus();
+      debugLog(
+        `Loaded animations for slide ${currentSlideIndex}:`,
+        animationsToUse,
+      );
+      if (shouldKeepExisting) {
+        debugLog(
+          '↩️  Keeping in-memory animations because parsed frontmatter was empty',
+        );
+      }
+
+      debugLog('setting markdown to', content, undefined, 'editor');
+      ref.current.setMarkdown(content);
+    } catch (error: any) {
+      debugLog('Could not set markdown', error, undefined, 'editor');
     }
+
+    ref.current.focus();
   }, [content, currentSlideIndex, currentCourse]); //DO NOT REMOVE currentSlideIndex
 
   /**

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/RapidCmi5Toolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/toolbar/RapidCmi5Toolbar.tsx
@@ -37,7 +37,6 @@ import {
   editorInPlayback$,
   lessonTheme$,
   CONTENT_UPDATED_COMMAND,
-  dividerColor,
   toolbarRect$,
   maxSlideWidth$,
   debugLog,
@@ -75,13 +74,13 @@ import { UndoRedo } from './components/UndoRedo';
 import { InsertQuotes } from './components/InsertQuotes';
 import { InsertStatements } from './components/InsertStatements';
 import { useRC5Prompts } from '../modals/useRC5Prompts';
+import { LessonTheme } from '@rapid-cmi5/cmi5-build-common';
 
 /**
  * Layout Constants
  *
  */
 const rightToolbarMargin = 25;
-
 
 /**
  * A toolbar component that includes all toolbar components.
@@ -90,13 +89,12 @@ const rightToolbarMargin = 25;
  * @group Toolbar Components
  */
 export const RapidCmi5Toolbar: React.FC<{
-  lessonTheme?: import('@rapid-cmi5/cmi5-build-common').LessonTheme;
+  lessonTheme?: LessonTheme;
 }> = ({ lessonTheme }) => {
   const changeViewMode = usePublisher(viewMode$);
   const { getMarkdownData } = useContext(RC5Context);
   const realm = useRealm();
   const viewmode = useCellValue(viewMode$);
-  const themedDividerColor = useSelector(dividerColor);
   const content = useSelector(displayData);
   const [editor] = useLexicalComposerContext();
   const toolbarRef = useRef<HTMLDivElement>(null);
@@ -189,7 +187,6 @@ export const RapidCmi5Toolbar: React.FC<{
     // Ensure the ref is attached to a DOM element and that element exists
   }, []);
 
-
   return (
     <Box
       ref={toolbarRef}
@@ -215,7 +212,11 @@ export const RapidCmi5Toolbar: React.FC<{
         <Stack direction="column" spacing={1} sx={{ padding: 1 }}>
           {viewmode === 'rich-text' && !isPlayback && (
             <Stack direction="row" spacing={1}>
-              <Stack direction="row" spacing={0} sx={{ flexGrow: 1, minWidth: 0 }}>
+              <Stack
+                direction="row"
+                spacing={0}
+                sx={{ flexGrow: 1, minWidth: 0 }}
+              >
                 <BoldItalicUnderlineToggles />
                 <ColorTextSplitButton />
                 <HighlightSplitButton />
@@ -307,8 +308,8 @@ export const RapidCmi5Toolbar: React.FC<{
           )}
           {(viewmode === 'source' ||
             (viewmode === 'rich-text' && isPlayback)) && (
-              <Box sx={{ minHeight: '32px' }}></Box>
-            )}
+            <Box sx={{ minHeight: '32px' }}></Box>
+          )}
           <Stack
             direction="row"
             spacing={1}
@@ -337,9 +338,9 @@ export const RapidCmi5Toolbar: React.FC<{
               direction="row"
               spacing={1}
               sx={{
-                background: alpha(theme.palette.primary.light, .10), //'background.default',
+                background: alpha(theme.palette.primary.light, 0.1), //'background.default',
                 borderRadius: '24px',
-                 border: `1px solid ${alpha(theme.palette.primary.main, 0.50)}`,
+                border: `1px solid ${alpha(theme.palette.primary.main, 0.5)}`,
                 height: '34px',
                 display: 'flex',
                 justifyContent: 'center',

--- a/packages/ui/src/lib/cmi5/mdx/plugins/diff-source/DiffViewer.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/diff-source/DiffViewer.tsx
@@ -1,58 +1,75 @@
-import React from 'react'
+import { useEffect, useRef } from 'react';
 
-import { cmExtensions$, diffMarkdown$, readOnlyDiff$ } from '.'
-import { markdown$, markdownSourceEditorValue$, onBlur$, readOnly$ } from '@mdxeditor/editor'
+import { cmExtensions$, diffMarkdown$, readOnlyDiff$ } from '.';
+import {
+  markdown$,
+  markdownSourceEditorValue$,
+  onBlur$,
+  readOnly$,
+} from '@mdxeditor/editor';
 
-import { MergeView } from '@codemirror/merge'
-import { EditorState } from '@codemirror/state'
-import { EditorView } from '@codemirror/view'
-import { COMMON_STATE_CONFIG_EXTENSIONS } from './SourceEditor'
-import { useCellValue, useCellValues, usePublisher, useRealm } from '@mdxeditor/gurx'
+import { MergeView } from '@codemirror/merge';
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { COMMON_STATE_CONFIG_EXTENSIONS } from './SourceEditor';
+import {
+  useCellValue,
+  useCellValues,
+  usePublisher,
+  useRealm,
+} from '@mdxeditor/gurx';
 
 function setContent(view: EditorView | undefined, content: string) {
   if (view !== undefined) {
-    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: content } })
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: content },
+    });
   }
 }
 
-export const DiffViewer: React.FC = () => {
-  const realm = useRealm()
-  const [newMarkdown, oldMarkdown, readOnly, readOnlyDiff] = useCellValues(markdown$, diffMarkdown$, readOnly$, readOnlyDiff$)
-  const onUpdate = usePublisher(markdownSourceEditorValue$)
-  const elRef = React.useRef<HTMLDivElement | null>(null)
-  const cmMergeViewRef = React.useRef<MergeView | null>(null)
-  const cmExtensions = useCellValue(cmExtensions$)
-  const triggerOnBlur = usePublisher(onBlur$)
+export const DiffViewer = () => {
+  const realm = useRealm();
+  const [newMarkdown, oldMarkdown, readOnly, readOnlyDiff] = useCellValues(
+    markdown$,
+    diffMarkdown$,
+    readOnly$,
+    readOnlyDiff$,
+  );
+  const onUpdate = usePublisher(markdownSourceEditorValue$);
+  const elRef = useRef<HTMLDivElement | null>(null);
+  const cmMergeViewRef = useRef<MergeView | null>(null);
+  const cmExtensions = useCellValue(cmExtensions$);
+  const triggerOnBlur = usePublisher(onBlur$);
 
-  React.useEffect(() => {
+  useEffect(() => {
     return realm.sub(diffMarkdown$, (newDiffMarkdown) => {
-      setContent(cmMergeViewRef.current?.a, newDiffMarkdown)
-    })
-  }, [realm])
+      setContent(cmMergeViewRef.current?.a, newDiffMarkdown);
+    });
+  }, [realm]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     return realm.sub(markdown$, (newMarkdown) => {
-      setContent(cmMergeViewRef.current?.b, newMarkdown)
-    })
-  }, [realm])
+      setContent(cmMergeViewRef.current?.b, newMarkdown);
+    });
+  }, [realm]);
 
-  React.useEffect(() => {
-    const isReadOnly = readOnly || readOnlyDiff
+  useEffect(() => {
+    const isReadOnly = readOnly || readOnlyDiff;
 
     const revertParams = isReadOnly
       ? ({
           renderRevertControl: undefined,
-          revertControls: undefined
+          revertControls: undefined,
         } as const)
       : ({
           renderRevertControl: () => {
-            const el = document.createElement('button')
-            el.classList.add('cm-merge-revert')
-            el.appendChild(document.createTextNode('\u2B95'))
-            return el
+            const el = document.createElement('button');
+            el.classList.add('cm-merge-revert');
+            el.appendChild(document.createTextNode('\u2B95'));
+            return el;
           },
-          revertControls: 'a-to-b'
-        } as const)
+          revertControls: 'a-to-b',
+        } as const);
 
     cmMergeViewRef.current = new MergeView({
       ...revertParams,
@@ -61,7 +78,11 @@ export const DiffViewer: React.FC = () => {
       gutter: true,
       a: {
         doc: oldMarkdown,
-        extensions: [...cmExtensions, ...COMMON_STATE_CONFIG_EXTENSIONS, EditorState.readOnly.of(true)]
+        extensions: [
+          ...cmExtensions,
+          ...COMMON_STATE_CONFIG_EXTENSIONS,
+          EditorState.readOnly.of(true),
+        ],
       },
       b: {
         doc: newMarkdown,
@@ -70,24 +91,23 @@ export const DiffViewer: React.FC = () => {
           ...COMMON_STATE_CONFIG_EXTENSIONS,
           EditorState.readOnly.of(isReadOnly),
           EditorView.updateListener.of(({ state }) => {
-            const md = state.doc.toString()
-            onUpdate(md)
+            const md = state.doc.toString();
+            onUpdate(md);
           }),
           EditorView.focusChangeEffect.of((_, focused) => {
             if (!focused) {
-              triggerOnBlur(new FocusEvent('blur'))
+              triggerOnBlur(new FocusEvent('blur'));
             }
-            return null
-          })
-        ]
-      }
-    })
+            return null;
+          }),
+        ],
+      },
+    });
     return () => {
-      cmMergeViewRef.current?.destroy()
-      cmMergeViewRef.current = null
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onUpdate, cmExtensions])
+      cmMergeViewRef.current?.destroy();
+      cmMergeViewRef.current = null;
+    };
+  }, [onUpdate, cmExtensions]);
 
-  return <div ref={elRef} className="mdxeditor-diff-editor" />
-}
+  return <div ref={elRef} className="mdxeditor-diff-editor" />;
+};

--- a/packages/ui/src/lib/cmi5/mdx/plugins/diff-source/SourceEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/diff-source/SourceEditor.tsx
@@ -3,7 +3,7 @@ import { Compartment } from '@codemirror/state';
 import { EditorState, Extension } from '@codemirror/state';
 import { EditorView, lineNumbers } from '@codemirror/view';
 import { basicSetup } from 'codemirror';
-import React, { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { githubLight, githubDark } from '@uiw/codemirror-theme-github';
 import { useTheme } from '@mui/material';
 import { cmExtensions$ } from '.';
@@ -12,8 +12,9 @@ import {
   markdownSourceEditorValue$,
   onBlur$,
   readOnly$,
+  setMarkdown$,
 } from '@mdxeditor/editor';
-import { useCellValues, usePublisher } from '@mdxeditor/gurx';
+import { useCellValues, usePublisher, useRealm } from '@mdxeditor/gurx';
 
 export const COMMON_STATE_CONFIG_EXTENSIONS: Extension[] = [
   basicSetup,
@@ -24,6 +25,7 @@ export const COMMON_STATE_CONFIG_EXTENSIONS: Extension[] = [
 ];
 
 export const SourceEditor = () => {
+  const realm = useRealm();
   const [markdown, readOnly, cmExtensions] = useCellValues(
     markdown$,
     readOnly$,
@@ -31,7 +33,7 @@ export const SourceEditor = () => {
   );
   const updateMarkdown = usePublisher(markdownSourceEditorValue$);
   const triggerOnBlur = usePublisher(onBlur$);
-  const editorViewRef = React.useRef<EditorView | null>(null);
+  const editorViewRef = useRef<EditorView | null>(null);
   const themeCompartment = useMemo(() => {
     return new Compartment();
   }, []);
@@ -71,15 +73,42 @@ export const SourceEditor = () => {
         editorViewRef.current = null;
       }
     },
-    [
-      markdown,
-      readOnly,
-      updateMarkdown,
-      cmExtensions,
-      editorViewRef,
-      triggerOnBlur,
-    ],
+    // `markdown` is intentionally omitted — we update doc content via the
+    // markdown$ subscription below instead of recreating the editor.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [readOnly, updateMarkdown, cmExtensions, triggerOnBlur],
   );
+
+  /**
+   * Push markdown changes into the existing editor view (e.g. on slide
+   * change) without tearing down and rebuilding the editor, so cursor,
+   * scroll, focus, and undo history are preserved.
+   *
+   * We subscribe to BOTH markdown$ and setMarkdown$ because MDXEditor's
+   * internal setMarkdown$ handler short-circuits when the new markdown
+   * trim-equals the current markdown$ value — meaning markdown$ never
+   * re-emits and Lexical is never updated. That breaks the source view
+   * when two slides share identical content but CodeMirror's doc has
+   * diverged via in-place source-mode edits. Subscribing to setMarkdown$
+   * directly bypasses that filter.
+   */
+  const replaceDoc = (next: string) => {
+    const view = editorViewRef.current;
+    if (!view) return;
+    if (view.state.doc.toString() === next) return;
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: next },
+    });
+  };
+
+  useEffect(() => {
+    const unsubMarkdown = realm.sub(markdown$, replaceDoc);
+    const unsubSetMarkdown = realm.sub(setMarkdown$, replaceDoc);
+    return () => {
+      unsubMarkdown();
+      unsubSetMarkdown();
+    };
+  }, [realm]);
 
   /**
    * Switch Themes


### PR DESCRIPTION
I could not reproduce the issue seen in the ticket regarding overwriting. I however did find that the markdown editing view has a bug that will overwrite all slides with the same content.
If you had several slides with the content # Slide, editing one of them in raw markdown view would change the value for all of them if you navigated through the slides while in markdown view.


Ticket #CCUI-2987
https://cybercents.atlassian.net/jira/software/c/projects/CCUI/boards/236?selectedIssue=CCUI-2987