### PR TITLE
Feature/cc UI 3019 wcag landing

### DIFF
--- a/apps/rapid-cmi5-electron-frontend/src/app/app.tsx
+++ b/apps/rapid-cmi5-electron-frontend/src/app/app.tsx
@@ -110,6 +110,9 @@ function AppWorkspace() {
         minHeight: 0,
       }}
     >
+      <a href="#app-routes" className="skip-link">
+        Skip to main content
+      </a>
       <AppHeader />
 
       <main

--- a/apps/rapid-cmi5-electron-frontend/src/app/shared/AppHeader.tsx
+++ b/apps/rapid-cmi5-electron-frontend/src/app/shared/AppHeader.tsx
@@ -109,7 +109,7 @@ export default function AppHeader() {
       {/* Right section - Settings and User */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         <IconButton
-          aria-label="user-settings"
+          aria-label="User Settings"
           id="settings-menu-anchor"
           onClick={() => onAppIconClick(settingsKey)}
           size="small"
@@ -143,7 +143,7 @@ export default function AppHeader() {
       {isElectron && (
         <>
           <IconButton
-            aria-label="terminal"
+            aria-label={terminalOpen ? 'Close Terminal' : 'Open Terminal'}
             aria-pressed={terminalOpen}
             disableTouchRipple
             onClick={handleOpenTerminal}
@@ -171,7 +171,7 @@ export default function AppHeader() {
             </Tooltip>
           </IconButton>
           <IconButton
-            aria-label="ai-tools"
+            aria-label={aiOpen ? 'Close AI Tools' : 'Open AI Tools'}
             aria-pressed={aiOpen}
             disableTouchRipple
             onClick={handleOpenAi}

--- a/apps/rapid-cmi5-electron-frontend/src/app/shared/AppHeader.tsx
+++ b/apps/rapid-cmi5-electron-frontend/src/app/shared/AppHeader.tsx
@@ -69,7 +69,7 @@ export default function AppHeader() {
    */
   const logoIcon = useMemo(() => {
     return (
-      <Stack direction="row" sx={{ paddingLeft: '4px' }}>
+      <Stack direction="row" sx={{ paddingLeft: '4px' }} aria-label="RapidCMI5">
         <RapidCmi5Icon isDarkThemeOnly={true} />
         <RapidCmi5Title />
       </Stack>

--- a/apps/rapid-cmi5-electron-frontend/src/app/shared/modals/CertificateManagerModal.tsx
+++ b/apps/rapid-cmi5-electron-frontend/src/app/shared/modals/CertificateManagerModal.tsx
@@ -103,7 +103,7 @@ export default function CertificateManagerModal({
                 secondaryAction={
                   <IconButton
                     edge="end"
-                    aria-label="delete"
+                    aria-label={`Delete ${cert.filename}`}
                     onClick={() => handleRemove(cert)}
                   >
                     <DeleteIcon />

--- a/apps/rapid-cmi5-electron-frontend/src/app/shared/modals/GitGlobalConfigModal.tsx
+++ b/apps/rapid-cmi5-electron-frontend/src/app/shared/modals/GitGlobalConfigModal.tsx
@@ -107,6 +107,7 @@ export function ConfigureGlobalGitConfigForm({
                   label="Git Username"
                   placeholder="user.name"
                   readOnly={false}
+                  autoComplete="username"
                 />
               </Grid>
 
@@ -135,6 +136,7 @@ export function ConfigureGlobalGitConfigForm({
               label="Author Name"
               placeholder="FirstName LastName"
               readOnly={false}
+              autoComplete="name"
             />
           </Grid>
 
@@ -148,6 +150,7 @@ export function ConfigureGlobalGitConfigForm({
               label="Author Email"
               placeholder="user@gmail.com"
               readOnly={false}
+              autoComplete="email"
             />
           </Grid>
           <Alert severity="info">

--- a/apps/rapid-cmi5-electron-frontend/src/styles.css
+++ b/apps/rapid-cmi5-electron-frontend/src/styles.css
@@ -110,6 +110,29 @@ div#horizontalgap {
   width: 0px;
 }
 
+/* Skip to main content link - visually hidden until focused */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  z-index: 10000;
+  padding: 12px 24px;
+  background: #000000;
+  color: #ffffff !important;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  border: 2px solid #ffffff;
+  border-radius: 0 0 4px 0;
+  white-space: nowrap;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 3px solid #6f96ff;
+  outline-offset: 2px;
+}
+
 /* REF  Scrollbar Styles
 Moved to theme
 */
@@ -427,13 +450,13 @@ align-items: center; */
 }
 
 /* Alternating row colors — activated by data-striped="true" on the table */
-.rc5-table[data-striped="true"] tbody tr:nth-child(odd) td {
+.rc5-table[data-striped='true'] tbody tr:nth-child(odd) td {
   background-color: var(--stripe-odd, #d6e4f7);
 }
-.rc5-table[data-striped="true"] tbody tr:nth-child(even) td {
+.rc5-table[data-striped='true'] tbody tr:nth-child(even) td {
   background-color: var(--stripe-even, #ffffff);
 }
 /* Explicit cell background-color (set via inline style) takes precedence */
-.rc5-table[data-striped="true"] tbody td[style*="background-color"] {
+.rc5-table[data-striped='true'] tbody td[style*='background-color'] {
   background-color: revert;
 }

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/ProjectSelection/Components/GlassCard.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/ProjectSelection/Components/GlassCard.tsx
@@ -61,10 +61,11 @@ export function GlassCard({
           {icon}
         </Box>
         <Typography
-          variant="h5"
+          variant="h2"
           sx={{
             fontFamily: '"Space Mono", monospace',
             fontWeight: 600,
+            fontSize: '18px',
           }}
         >
           {title}

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/ProjectSelection/Components/OptionCard.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/ProjectSelection/Components/OptionCard.tsx
@@ -1,4 +1,4 @@
-import { Info, InfoOutlined } from '@mui/icons-material';
+import { Info } from '@mui/icons-material';
 import {
   ListItem,
   ListItemButton,
@@ -34,87 +34,91 @@ const OptionCard = ({
 
   return (
     <ThemedOptionCard>
-      {/* Apply to outer or inner element */}
-      <ListItemButton
-        data-testid={dataTestId}
-        onClick={handleSelect}
-        disabled={disabled}
-        sx={{
-          borderRadius: 2,
-          p: 1.2,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-start',
-          gap: 0.5,
-          transition: 'none',
-          '&:hover': {
-            background: 'transparent',
-          },
-        }}
-      >
-        {/* Header Row */}
-        <Box
+      <Box sx={{ position: 'relative' }}>
+        <ListItemButton
+          data-testid={dataTestId}
+          onClick={handleSelect}
+          disabled={disabled}
           sx={{
+            borderRadius: 2,
+            p: 1.2,
+            pr: 5,
             display: 'flex',
-            alignItems: 'center',
-            width: '100%',
-            gap: 1,
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            gap: 0.5,
+            transition: 'none',
+            '&:hover': {
+              background: 'transparent',
+            },
           }}
         >
-          <ListItemIcon
+          {/* Header Row */}
+          <Box
             sx={{
-              minWidth: 'auto',
-              color: alpha(palette.primary.main, 0.9),
+              display: 'flex',
+              alignItems: 'center',
+              width: '100%',
+              gap: 1,
             }}
           >
-            {icon}
-          </ListItemIcon>
-          <ListItemText
-            primary={title}
-            sx={{
-              margin: 0,
-              flex: 1,
-              fontFamily: '"IBM Plex Sans", sans-serif',
-              fontWeight: 500,
-              fontSize: '14px',
-              letterSpacing: '0.01em',
-            }}
-          />
-          <IconButton
-            size="small"
-            onClick={(e) => {
-              e.stopPropagation();
-              handleShowDocs();
-            }}
-            disabled={disabled}
-            sx={{
-              color: alpha(palette.primary.main, 0.8),
-              transition: 'all 0.2s ease',
-              '&:hover': {
+            <ListItemIcon
+              sx={{
+                minWidth: 'auto',
                 color: alpha(palette.primary.main, 0.9),
-                background: alpha(palette.primary.main, 0.15),
-                transform: 'scale(1.1)',
-              },
+              }}
+            >
+              {icon}
+            </ListItemIcon>
+            <ListItemText
+              primary={title}
+              sx={{
+                margin: 0,
+                flex: 1,
+                fontFamily: '"IBM Plex Sans", sans-serif',
+                fontWeight: 500,
+                fontSize: '14px',
+                letterSpacing: '0.01em',
+              }}
+            />
+          </Box>
+
+          {/* Description Text */}
+          <Typography
+            variant="body2"
+            sx={{
+              fontSize: '0.8rem',
+              fontFamily: '"IBM Plex Sans", sans-serif',
+              lineHeight: 1.4,
+              pl: 1,
+              width: '100%',
             }}
           >
-            <Info fontSize="small" />
-          </IconButton>
-        </Box>
+            {subText}
+          </Typography>
+        </ListItemButton>
 
-        {/* Description Text */}
-        <Typography
-          variant="body2"
+        <IconButton
+          aria-label={`Information about ${title}`}
+          size="small"
+          onClick={handleShowDocs}
+          disabled={disabled}
           sx={{
-            fontSize: '0.8rem',
-            fontFamily: '"IBM Plex Sans", sans-serif',
-            lineHeight: 1.4,
-            pl: 1,
-            width: '100%',
+            position: 'absolute',
+            top: 8,
+            right: 8,
+            color: alpha(palette.primary.main, 0.8),
+            transition: 'all 0.2s ease',
+            '&:hover': {
+              color: alpha(palette.primary.main, 0.9),
+              background: alpha(palette.primary.main, 0.15),
+              transform: 'scale(1.1)',
+            },
           }}
         >
-          {subText}
-        </Typography>
-      </ListItemButton>
+          <Info fontSize="small" />
+        </IconButton>
+      </Box>
     </ThemedOptionCard>
   );
 };

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/ProjectSelection/SelectProject.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/ProjectSelection/SelectProject.tsx
@@ -9,7 +9,7 @@ import { RootState } from '../../../redux/store';
 import WebAppSelection from './Components/WebAppSelection';
 import ElectronAppSelection from './Components/ElectronSelection';
 import CloneLoadingOverlay from './Components/LoadingOverlay';
-import { useToaster } from '@rapid-cmi5/ui';
+import { HiddenHeader, useToaster } from '@rapid-cmi5/ui';
 import { DirMeta } from '@rapid-cmi5/cmi5-build-common';
 import { CustomTheme } from '../styles/createPalette';
 
@@ -86,7 +86,7 @@ export default function SelectProjectHomePage({}: {}) {
   };
 
   useEffect(() => {
-   populateRecentProjects();
+    populateRecentProjects();
   }, []);
 
   const handleOpenRecentProject = async (id: string) => {
@@ -134,6 +134,7 @@ export default function SelectProjectHomePage({}: {}) {
         overflow: 'auto',
       }}
     >
+      <HiddenHeader header="Projects Dashboard" />
       <Box
         sx={{
           height: '100vh',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,6 +3,7 @@
 export { config } from './lib/environments/FrontendEnvironment.env';
 
 export * from './lib/navigation/paging/paginationFiltersConstants';
+export * from './lib/accessibility/HiddenHeader';
 export * from './lib/apps/AppLogo';
 export * from './lib/apps/RapidCmi5Icon';
 export * from './lib/apps/RapidCmi5Title';

--- a/packages/ui/src/lib/accessibility/HiddenHeader.tsx
+++ b/packages/ui/src/lib/accessibility/HiddenHeader.tsx
@@ -22,9 +22,6 @@ export function HiddenHeader({
     <Typography
       component={variant}
       sx={{
-        // backgroundColor: 'pink',
-        // width: '20px',
-        // height: '20px',
         position: 'absolute',
         width: '1px',
         height: '1px',

--- a/packages/ui/src/lib/accessibility/HiddenHeader.tsx
+++ b/packages/ui/src/lib/accessibility/HiddenHeader.tsx
@@ -1,0 +1,42 @@
+import { Typography, TypographyVariant } from '@mui/material';
+import { useEffect } from 'react';
+
+export function HiddenHeader({
+  header,
+  pageTitle,
+  variant = 'h1',
+}: {
+  header: string;
+  pageTitle?: string;
+  variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}) {
+  /**
+   * 2.4.2 Page Titled (Level A) requires that each page has a title that describes its topic or purpose
+   */
+  useEffect(() => {
+
+    document.title = `${pageTitle || header} | RangeOS`;
+  }, [header]);
+
+  return (
+    <Typography
+      component={variant}
+      sx={{
+        // backgroundColor: 'pink',
+        // width: '20px',
+        // height: '20px',
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        border: 0,
+      }}
+    >
+      {header}
+    </Typography>
+  );
+}
+
+export default HiddenHeader;

--- a/packages/ui/src/lib/forms/FormControlTextField.tsx
+++ b/packages/ui/src/lib/forms/FormControlTextField.tsx
@@ -15,6 +15,7 @@ import ReadOnlyTextField from './ReadOnlyTextField';
 import { ButtonIcon, ButtonInfoField } from '../utility/buttons';
 
 export type tFormControlTextFieldProps = {
+  autoComplete?: string;
   control?: Control;
   disabled?: boolean;
   error?: boolean;
@@ -37,6 +38,7 @@ export type tFormControlTextFieldProps = {
 };
 
 export function FormControlTextField({
+  autoComplete = 'off',
   control,
   disabled = true,
   error = false,
@@ -93,7 +95,7 @@ export function FormControlTextField({
               <div className="content-row">
                 {!readOnly ? (
                   <TextField
-                    autoComplete="off"
+                    autoComplete={autoComplete}
                     sx={{
                       borderRadius: '4px',
                       ...sxProps,

--- a/packages/ui/src/lib/styles/muiThemeDark.ts
+++ b/packages/ui/src/lib/styles/muiThemeDark.ts
@@ -26,7 +26,7 @@ export const darkTheme = createTheme({
       main: mainColor,
       dark: '#3C59A2',
       light: hoverMainColor,
-      contrastText: '#212121',
+      contrastText: '#fff',
     },
     secondary: {
       main: '#ed6c02', //#A5BEFF


### PR DESCRIPTION
---
  **WCAG Accessibility Improvements — Landing **

  **Summary**

  Addresses multiple WCAG 2.x violations on the landing page during an accessibility audit.

  ---
  **Changes**

  **Nested interactive controls (WCAG 4.1.3)**
  - OptionCard: The info IconButton was nested inside ListItemButton, violating the rule that interactive controls
  must not be nested. Restructured using a relative-positioned wrapper so both controls are siblings. Added
  aria-label="Information about {title}" to the previously unlabelled info button.
  
  **Accessible names must match visible labels (WCAG 2.5.3)**
  - AppHeader: Button aria-label values did not match their tooltip text, breaking speech input (e.g. "click User
  Settings" would not activate a button labelled "user-settings"). Fixed to match tooltip text exactly. Toggle buttons
  (Terminal, AI Tools) now update their label dynamically to reflect open/closed state.
  - CertificateManagerModal: All delete buttons in the certificate list shared the same aria-label="delete", making
  them indistinguishable for screen reader users. Now scoped to the filename: "Delete {cert.filename}".
  
  **Skip navigation (WCAG 2.4.1)**
  - Added a visually hidden "Skip to main content" link at the top of the app shell that becomes visible on focus.
  Allows keyboard users to bypass the header on every page.
  
  **Page title / heading structure (WCAG 2.4.2, 2.4.6)**
  - Added a new reusable HiddenHeader component (exported from @rapid-cmi5/ui) that renders a visually hidden heading
  and updates document.title. Applied to the Projects Dashboard view.
  - GlassCard: Section heading was rendered as h5 with no parent h1–h4, breaking heading hierarchy. Changed to h2 with
  fontSize: '18px' to preserve visual appearance.
  
  **Autocomplete on personal data fields (WCAG 1.3.5)**
  - Added autoComplete prop to FormControlTextField (defaults to "off", no breaking change).
  - GitGlobalConfigModal: Author Name, Author Email, and Git Username fields now declare autoComplete="name", "email",
  and "username" respectively, enabling browser autofill and assistive technology support.

  **Color contrast**
  - muiThemeDark: Primary contrastText corrected from #212121 (dark on dark) to #fff to meet contrast requirements
  against the dark theme primary color.

---
  **Testing**
  
  - [ ] Keyboard-only navigation through the landing page — skip link appears on first Tab, reaches main content
  - [ ] Screen reader (VoiceOver / NVDA) announces logo as "RapidCMI5", header buttons with correct names, delete
  buttons with filename context
  - [ ] Info button on OptionCard is independently focusable and does not trigger card selection
  - [ ] Browser autofill populates Author Name and Email fields in Git Config modal
  - [ ] No visual regressions on GlassCard headings or OptionCard layout