### PR TITLE
fix: Moodle-launched scenario header never updates to Ready

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/scenario/graph/ScenarioSubscription.tsx
+++ b/apps/cc-cmi5-player/src/app/components/scenario/graph/ScenarioSubscription.tsx
@@ -42,7 +42,13 @@ export default function ScenarioSubscription({
     query: scenarioUpdatedQuery,
     variables: {
       rangeId: rangeId,
-      scenarioId: scenarioId,
+      // The query declares $uuid (scenarioUpdated(uuid: $uuid)); this MUST be
+      // keyed `uuid`, not `scenarioId`. Passing `scenarioId` left $uuid unbound
+      // → the server filter never matched → ZERO scenarioUpdated events → the
+      // scenario header stayed stuck NotReady (while console/VM subscriptions,
+      // which correctly declare+pass $scenarioId, worked fine). scenarioId IS
+      // the scenario's uuid.
+      uuid: scenarioId,
     },
   };
 
@@ -60,7 +66,15 @@ export default function ScenarioSubscription({
       if (updateScenarioSubscription?.data?.data?.scenarioUpdated) {
         const scenario = updateScenarioSubscription.data.data
           .scenarioUpdated as Partial<DeployedScenarioData>;
-        if (Object.prototype.hasOwnProperty.call(scenario, 'packages')) {
+        // Accept the update if it carries packages OR a status. The original
+        // guard only let through events with a `packages` field, which would
+        // DROP a status-only update (e.g. NotReady → Ready) — so even once
+        // events arrive, the header could miss the Ready transition. Gating on
+        // status too lets the scenario header advance on status-only pushes.
+        if (
+          Object.prototype.hasOwnProperty.call(scenario, 'packages') ||
+          scenario.status !== undefined
+        ) {
           setUpdate(scenario, Topic.ResourceScenario);
         }
       }

--- a/libs/frontend/clients/hooks/src/lib/api/useGraphQLClient.ts
+++ b/libs/frontend/clients/hooks/src/lib/api/useGraphQLClient.ts
@@ -8,6 +8,15 @@ export const useGraphQLClient = (subscriptionsUrl?: string) => {
   }
 
   const authorization = queryHooksConfig.headers.Authorization;
+  // Recreate the client when the subscriptions URL (or auth) changes. The
+  // player loads its config from cfg.json ASYNCHRONOUSLY, so on first render
+  // config.DEVOPS_GQL_SUBSCRIPTIONS_URL is still empty and
+  // getGraphQLSubscriptionsUrl() returns the 'http://localhost' fallback. With
+  // empty deps ([]) the memo captured that localhost URL forever and the WS
+  // never connected (→ no scenarioUpdated events → scenario header stuck
+  // NotReady). Depending on subscriptionsUrl lets the client rebuild once
+  // cfg.json resolves the real wss:// URL. (The dashboard loads env-config.js
+  // synchronously, so its URL is correct on first render and this never churns.)
   return useMemo(
     () =>
       createClient({
@@ -16,6 +25,6 @@ export const useGraphQLClient = (subscriptionsUrl?: string) => {
           authorization,
         }),
       }),
-    [],
+    [subscriptionsUrl, authorization],
   );
 };


### PR DESCRIPTION
Scenario activities launched through Moodle stayed stuck NotReady in the player UI even though the VM was Ready and the console connected. Two defects in the GraphQL scenario-status subscription path:

1. ScenarioSubscription declared $uuid but passed `scenarioId` as the variable key, leaving $uuid unbound. The server-side scenarioUpdated(uuid: $uuid) filter never matched, so ZERO scenario status events were delivered and the header never advanced. (Console/VM subscriptions correctly declare+pass $scenarioId, which is why the console worked while the status did not.) Fix: key the variable `uuid`. Also broaden the update guard to accept status-only pushes, not just events carrying a `packages` field, so a NotReady->Ready transition is not dropped.

2. useGraphQLClient memoized the graphql-ws client with empty deps, so the client captured the `http://localhost` fallback that getGraphQLSubscriptionsUrl() returns before cfg.json loads asynchronously (the player has no synchronous env-config.js). It never rebuilt once the real wss:// URL arrived. Fix: depend on [subscriptionsUrl, authorization] so the client rebuilds when the URL resolves. (The dashboard loads env-config.js synchronously and is unaffected.)