### PR TITLE
feat: Add generic text support to audio component (CCUI-3042)

### DIFF
--- a/apps/cc-cmi5-player/webpack.config.js
+++ b/apps/cc-cmi5-player/webpack.config.js
@@ -164,7 +164,10 @@ module.exports = composePlugins(withNx(), withReact(), (config) => {
           req.on('end', () => {
             try {
               JSON.parse(body); // validate
-              fs.mkdirSync(TEST_DIR, { recursive: true });
+              // Create the config's parent (src/test/au), not just src/test —
+              // otherwise writeFileSync throws ENOENT when au/ is absent
+              // (e.g. fresh clone or after a clean).
+              fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
               fs.writeFileSync(TEST_CONFIG_PATH, body, 'utf-8');
               res.json({ success: true });
             } catch (err) {
@@ -210,7 +213,8 @@ module.exports = composePlugins(withNx(), withReact(), (config) => {
                   error: `config.json not found at ${lessonDirPath}/config.json in zip`,
                 });
               }
-              fs.mkdirSync(TEST_DIR, { recursive: true });
+              // Create the config's parent (src/test/au), not just src/test.
+              fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
               fs.writeFileSync(
                 TEST_CONFIG_PATH,
                 configEntry.getData().toString('utf-8'),
@@ -323,7 +327,8 @@ module.exports = composePlugins(withNx(), withReact(), (config) => {
                   error: `config.json not found at ${lessonDirPath}/config.json in zip`,
                 });
               }
-              fs.mkdirSync(TEST_DIR, { recursive: true });
+              // Create the config's parent (src/test/au), not just src/test.
+              fs.mkdirSync(path.dirname(TEST_CONFIG_PATH), { recursive: true });
               fs.writeFileSync(
                 TEST_CONFIG_PATH,
                 configEntry.getData().toString('utf-8'),

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioDialog.tsx
@@ -6,7 +6,6 @@ import {
   audioDialogState$,
   audioFilePath$,
 } from './index';
-import { CaptionKind } from './AudioNode';
 
 import { useCellValues, usePublisher } from '@mdxeditor/gurx';
 
@@ -17,8 +16,6 @@ import {
   Paper,
   Stack,
   Switch,
-  Tab,
-  Tabs,
   Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -66,9 +63,6 @@ export const AudioDialog: React.FC = () => {
   const [captionSrc, setCaptionSrc] = useState<string>('');
   const [selectedCaptionFiles, setSelectedCaptionFiles] = useState<FileList | null>(null);
   const [captionFileOptions, setCaptionFileOptions] = useState<string[]>([]);
-  // Transcript source mode. The active tab IS the caption kind.
-  const [captionKind, setCaptionKind] = useState<CaptionKind>('vtt');
-  const [captionText, setCaptionText] = useState<string>('');
 
 
 
@@ -88,9 +82,6 @@ export const AudioDialog: React.FC = () => {
       setAudioStyle('');
       setAutoplay(state.initialValues.autoplay ?? false);
       setCaptionSrc(state.initialValues.captionSrc ?? '');
-      setCaptionText(state.initialValues.captionText ?? '');
-      // Default to 'vtt' for back-compat (existing nodes have no captionKind).
-      setCaptionKind(state.initialValues.captionKind ?? 'vtt');
       if (state.initialValues.rest) {
         const styleAttribute = state.initialValues.rest.find(
           //@ts-ignore
@@ -107,8 +98,6 @@ export const AudioDialog: React.FC = () => {
       setAudioStyle('');
       setAutoplay(false);
       setCaptionSrc('');
-      setCaptionText('');
-      setCaptionKind('vtt');
     }
 
     // clear files regardless of editing state
@@ -144,12 +133,10 @@ export const AudioDialog: React.FC = () => {
       title: title,
       rest: restParams,
       autoplay: autoplay,
-      captionKind: captionKind,
-      // Only send the field for the active mode; the save handler enforces
-      // mutual exclusion, but this keeps the payload clean.
-      captionSrc: captionKind === 'vtt' ? captionSrc || undefined : undefined,
-      captionFile: captionKind === 'vtt' ? selectedCaptionFiles : undefined,
-      captionText: captionKind === 'text' ? captionText || undefined : undefined,
+      // Single caption file (`.vtt` or `.txt`); newly uploaded file takes
+      // precedence over an existing path in the save handler.
+      captionSrc: captionSrc || undefined,
+      captionFile: selectedCaptionFiles,
     };
 
     saveAudio(audioParams);
@@ -183,9 +170,9 @@ export const AudioDialog: React.FC = () => {
     });
   }, [audioFilePath, src, state.type]);
 
-  // fetch available .vtt files from the audio directory
+  // fetch available caption files (.vtt or .txt) from the audio directory
   useEffect(() => {
-    async function fetchVttFiles() {
+    async function fetchCaptionFiles() {
       try {
         const files = await getAllAssets('audio');
 
@@ -193,17 +180,22 @@ export const AudioDialog: React.FC = () => {
           files.push(state.initialValues.captionSrc.replace(AUDIO_DIR, ''));
         }
 
-        const vttOptions = [
-          ...new Set(files.filter((fileName) => fileName.endsWith('.vtt'))),
+        const captionOptions = [
+          ...new Set(
+            files.filter(
+              (fileName) =>
+                fileName.endsWith('.vtt') || fileName.endsWith('.txt'),
+            ),
+          ),
         ];
 
-        setCaptionFileOptions(vttOptions);
+        setCaptionFileOptions(captionOptions);
       } catch {
         setCaptionFileOptions([]);
       }
     }
 
-    void fetchVttFiles();
+    void fetchCaptionFiles();
   }, [audioFilePath, state.type]);
 
   // handle file selection
@@ -349,77 +341,53 @@ export const AudioDialog: React.FC = () => {
               infoText="Inline styles Ex. border-radius:8px;"
             />
 
-            {/* Transcript section — VTT (timed) or plain text. The selected
-                tab is the source of truth (captionKind). */}
+            {/* Transcript section — a single caption file, either a timed
+                WebVTT (.vtt) or a plain-text (.txt) transcript. The file's
+                content decides how it renders in the player, so authors just
+                pick a file without choosing a mode. */}
             <Paper variant="outlined" sx={{ p: 2 }}>
               <Stack spacing={2}>
                 <Typography variant="subtitle2">Transcript / Captions</Typography>
-                <Tabs
-                  value={captionKind}
-                  onChange={(_e, value: CaptionKind) => setCaptionKind(value)}
-                  variant="fullWidth"
-                >
-                  <Tab label="VTT (timed)" value="vtt" />
-                  <Tab label="Text" value="text" />
-                </Tabs>
-
-                {captionKind === 'vtt' ? (
-                  <Stack spacing={2}>
-                    <Stack direction="row" spacing={2}>
-                      <ButtonModalMainUi
-                        component="label"
-                        role={undefined}
-                        tabIndex={-1}
-                        startIcon={<UploadFileIcon />}
-                      >
-                        Upload VTT
-                        <VisuallyHiddenInput
-                          type="file"
-                          accept=".vtt"
-                          onChange={handleCaptionFileSelected}
-                        />
-                      </ButtonModalMainUi>
-                      <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                        <Typography variant="caption">
-                          {selectedCaptionFiles && selectedCaptionFiles.length > 0
-                            ? selectedCaptionFiles[0].name
-                            : 'No VTT file chosen'}
-                        </Typography>
-                      </Box>
-                    </Stack>
-                    <ComboBoxSelectorUi
-                      label="Caption File"
-                      id="audio-caption"
-                      options={captionFileOptions}
-                      defaultValue={captionSrc.replace(AUDIO_DIR, '')}
-                      showAllOptions={true}
-                      autocompleteProps={{ freeSolo: true }}
-                      onSelect={(selectionValue: any) => {
-                        if (!selectionValue) {
-                          setCaptionSrc('');
-                        } else if (selectionValue.startsWith('http')) {
-                          setCaptionSrc(selectionValue);
-                        } else {
-                          setCaptionSrc(`${AUDIO_DIR}${selectionValue}`);
-                        }
-                      }}
-                      infoText="Associate a WebVTT (.vtt) transcript file with this audio. The transcript will be displayed below the audio player."
+                <Stack direction="row" spacing={2}>
+                  <ButtonModalMainUi
+                    component="label"
+                    role={undefined}
+                    tabIndex={-1}
+                    startIcon={<UploadFileIcon />}
+                  >
+                    Upload Transcript
+                    <VisuallyHiddenInput
+                      type="file"
+                      accept=".vtt,.txt"
+                      onChange={handleCaptionFileSelected}
                     />
-                  </Stack>
-                ) : (
-                  <TextFieldMainUi
-                    margin="dense"
-                    label="Transcript text"
-                    name="audio-caption-text"
-                    type="text"
-                    fullWidth
-                    multiline
-                    minRows={4}
-                    value={captionText}
-                    onChange={(textValue: string) => setCaptionText(textValue)}
-                    infoText="Plain-text transcript shown below the audio player. Unlike VTT, it has no timing, highlighting, or click-to-seek."
-                  />
-                )}
+                  </ButtonModalMainUi>
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <Typography variant="caption">
+                      {selectedCaptionFiles && selectedCaptionFiles.length > 0
+                        ? selectedCaptionFiles[0].name
+                        : 'No transcript file chosen'}
+                    </Typography>
+                  </Box>
+                </Stack>
+                <ComboBoxSelectorUi
+                  label="Transcript File"
+                  id="audio-caption"
+                  options={captionFileOptions}
+                  defaultValue={captionSrc.replace(AUDIO_DIR, '')}
+                  showAllOptions={true}
+                  autocompleteProps={{ freeSolo: true }}
+                  onSelect={(selectionValue: any) => {
+                    if (!selectionValue) {
+                      setCaptionSrc('');
+                    } else if (selectionValue.startsWith('http')) {
+                      setCaptionSrc(selectionValue);
+                    } else {
+                      setCaptionSrc(`${AUDIO_DIR}${selectionValue}`);
+                    }
+                  }}
+                  infoText="Associate a transcript file with this audio. A timed WebVTT (.vtt) file shows a clickable, highlighted transcript; a plain-text (.txt) file shows a static transcript. Either way it appears below the audio player."
+                />
               </Stack>
             </Paper>
 

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioDialog.tsx
@@ -6,6 +6,7 @@ import {
   audioDialogState$,
   audioFilePath$,
 } from './index';
+import { CaptionKind } from './AudioNode';
 
 import { useCellValues, usePublisher } from '@mdxeditor/gurx';
 
@@ -16,6 +17,8 @@ import {
   Paper,
   Stack,
   Switch,
+  Tab,
+  Tabs,
   Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -63,6 +66,9 @@ export const AudioDialog: React.FC = () => {
   const [captionSrc, setCaptionSrc] = useState<string>('');
   const [selectedCaptionFiles, setSelectedCaptionFiles] = useState<FileList | null>(null);
   const [captionFileOptions, setCaptionFileOptions] = useState<string[]>([]);
+  // Transcript source mode. The active tab IS the caption kind.
+  const [captionKind, setCaptionKind] = useState<CaptionKind>('vtt');
+  const [captionText, setCaptionText] = useState<string>('');
 
 
 
@@ -82,6 +88,9 @@ export const AudioDialog: React.FC = () => {
       setAudioStyle('');
       setAutoplay(state.initialValues.autoplay ?? false);
       setCaptionSrc(state.initialValues.captionSrc ?? '');
+      setCaptionText(state.initialValues.captionText ?? '');
+      // Default to 'vtt' for back-compat (existing nodes have no captionKind).
+      setCaptionKind(state.initialValues.captionKind ?? 'vtt');
       if (state.initialValues.rest) {
         const styleAttribute = state.initialValues.rest.find(
           //@ts-ignore
@@ -98,6 +107,8 @@ export const AudioDialog: React.FC = () => {
       setAudioStyle('');
       setAutoplay(false);
       setCaptionSrc('');
+      setCaptionText('');
+      setCaptionKind('vtt');
     }
 
     // clear files regardless of editing state
@@ -133,8 +144,12 @@ export const AudioDialog: React.FC = () => {
       title: title,
       rest: restParams,
       autoplay: autoplay,
-      captionSrc: captionSrc || undefined,
-      captionFile: selectedCaptionFiles,
+      captionKind: captionKind,
+      // Only send the field for the active mode; the save handler enforces
+      // mutual exclusion, but this keeps the payload clean.
+      captionSrc: captionKind === 'vtt' ? captionSrc || undefined : undefined,
+      captionFile: captionKind === 'vtt' ? selectedCaptionFiles : undefined,
+      captionText: captionKind === 'text' ? captionText || undefined : undefined,
     };
 
     saveAudio(audioParams);
@@ -334,50 +349,77 @@ export const AudioDialog: React.FC = () => {
               infoText="Inline styles Ex. border-radius:8px;"
             />
 
-            {/* Caption / Transcript (VTT) section */}
+            {/* Transcript section — VTT (timed) or plain text. The selected
+                tab is the source of truth (captionKind). */}
             <Paper variant="outlined" sx={{ p: 2 }}>
               <Stack spacing={2}>
-                <Typography variant="subtitle2">Transcript / Captions (VTT)</Typography>
-                <Stack direction="row" spacing={2}>
-                  <ButtonModalMainUi
-                    component="label"
-                    role={undefined}
-                    tabIndex={-1}
-                    startIcon={<UploadFileIcon />}
-                  >
-                    Upload VTT
-                    <VisuallyHiddenInput
-                      type="file"
-                      accept=".vtt"
-                      onChange={handleCaptionFileSelected}
+                <Typography variant="subtitle2">Transcript / Captions</Typography>
+                <Tabs
+                  value={captionKind}
+                  onChange={(_e, value: CaptionKind) => setCaptionKind(value)}
+                  variant="fullWidth"
+                >
+                  <Tab label="VTT (timed)" value="vtt" />
+                  <Tab label="Text" value="text" />
+                </Tabs>
+
+                {captionKind === 'vtt' ? (
+                  <Stack spacing={2}>
+                    <Stack direction="row" spacing={2}>
+                      <ButtonModalMainUi
+                        component="label"
+                        role={undefined}
+                        tabIndex={-1}
+                        startIcon={<UploadFileIcon />}
+                      >
+                        Upload VTT
+                        <VisuallyHiddenInput
+                          type="file"
+                          accept=".vtt"
+                          onChange={handleCaptionFileSelected}
+                        />
+                      </ButtonModalMainUi>
+                      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                        <Typography variant="caption">
+                          {selectedCaptionFiles && selectedCaptionFiles.length > 0
+                            ? selectedCaptionFiles[0].name
+                            : 'No VTT file chosen'}
+                        </Typography>
+                      </Box>
+                    </Stack>
+                    <ComboBoxSelectorUi
+                      label="Caption File"
+                      id="audio-caption"
+                      options={captionFileOptions}
+                      defaultValue={captionSrc.replace(AUDIO_DIR, '')}
+                      showAllOptions={true}
+                      autocompleteProps={{ freeSolo: true }}
+                      onSelect={(selectionValue: any) => {
+                        if (!selectionValue) {
+                          setCaptionSrc('');
+                        } else if (selectionValue.startsWith('http')) {
+                          setCaptionSrc(selectionValue);
+                        } else {
+                          setCaptionSrc(`${AUDIO_DIR}${selectionValue}`);
+                        }
+                      }}
+                      infoText="Associate a WebVTT (.vtt) transcript file with this audio. The transcript will be displayed below the audio player."
                     />
-                  </ButtonModalMainUi>
-                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                    <Typography variant="caption">
-                      {selectedCaptionFiles && selectedCaptionFiles.length > 0
-                        ? selectedCaptionFiles[0].name
-                        : 'No VTT file chosen'}
-                    </Typography>
-                  </Box>
-                </Stack>
-                <ComboBoxSelectorUi
-                  label="Caption File"
-                  id="audio-caption"
-                  options={captionFileOptions}
-                  defaultValue={captionSrc.replace(AUDIO_DIR, '')}
-                  showAllOptions={true}
-                  autocompleteProps={{ freeSolo: true }}
-                  onSelect={(selectionValue: any) => {
-                    if (!selectionValue) {
-                      setCaptionSrc('');
-                    } else if (selectionValue.startsWith('http')) {
-                      setCaptionSrc(selectionValue);
-                    } else {
-                      setCaptionSrc(`${AUDIO_DIR}${selectionValue}`);
-                    }
-                  }}
-                  infoText="Associate a WebVTT (.vtt) transcript file with this audio. The transcript will be displayed below the audio player."
-                />
+                  </Stack>
+                ) : (
+                  <TextFieldMainUi
+                    margin="dense"
+                    label="Transcript text"
+                    name="audio-caption-text"
+                    type="text"
+                    fullWidth
+                    multiline
+                    minRows={4}
+                    value={captionText}
+                    onChange={(textValue: string) => setCaptionText(textValue)}
+                    infoText="Plain-text transcript shown below the audio player. Unlike VTT, it has no timing, highlighting, or click-to-seek."
+                  />
+                )}
               </Stack>
             </Paper>
 

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
@@ -23,7 +23,7 @@ import {
   editAudioToolbarComponent$,
   disableAudioSettingsButton$,
 } from './index';
-import { $isAudioNode, CaptionKind } from './AudioNode';
+import { $isAudioNode } from './AudioNode';
 import styles from './styles/audio-plugin.module.css';
 import { AudioTranscript } from './AudioTranscript';
 import { useCellValues } from '@mdxeditor/gurx';
@@ -38,7 +38,7 @@ interface AudioComponentProps {
   captionSrc?: string;
   /** Fetchable caption URL (blob in the builder, relative path in the player). */
   resolvedCaptionSrc?: string;
-  /** Plain-text transcript (when captionKind === 'text'). */
+  /** Back-compat: legacy inline transcript text, rendered read-only. */
   captionText?: string;
 }
 
@@ -221,8 +221,7 @@ function AudioComponent({
           muted={false}
           data-audio-id={id}
           data-caption-src={captionSrc}
-          data-caption-kind={captionText ? 'text' : undefined}
-          data-caption-text={captionText}
+          data-caption-text={!captionSrc ? captionText : undefined}
           style={{
             display: 'block',
             maxWidth: '100%',
@@ -231,16 +230,11 @@ function AudioComponent({
             pointerEvents: 'auto',
           }}
         />
-        {captionText ? (
-          <AudioTranscript text={captionText} audioRef={audioRef} />
-        ) : (
-          resolvedCaptionSrc && (
-            <AudioTranscript
-              captionSrc={resolvedCaptionSrc}
-              audioRef={audioRef}
-            />
-          )
-        )}
+        <AudioTranscript
+          captionSrc={resolvedCaptionSrc}
+          fallbackText={captionText}
+          audioRef={audioRef}
+        />
       </div>
     </React.Suspense>
   );
@@ -254,7 +248,7 @@ export interface AudioEditorProps {
   id: string;
   autoplay: boolean;
   captionSrc?: string;
-  captionKind?: CaptionKind;
+  /** Back-compat: legacy inline transcript text, rendered read-only. */
   captionText?: string;
 }
 
@@ -266,7 +260,6 @@ export function AudioEditor({
   id,
   autoplay,
   captionSrc,
-  captionKind,
   captionText,
 }: AudioEditorProps): JSX.Element {
   const [audioFilePath] = useCellValues(audioFilePath$);
@@ -335,7 +328,7 @@ export function AudioEditor({
           id={id}
           captionSrc={captionSrc}
           resolvedCaptionSrc={previewCaptionSrc}
-          captionText={captionKind === 'text' ? captionText : undefined}
+          captionText={captionText}
         />
         {shouldShowToolbar && (
           <EditAudioToolbar
@@ -346,8 +339,6 @@ export function AudioEditor({
             rest={rest}
             autoplay={autoplay}
             captionSrc={captionSrc}
-            captionKind={captionKind}
-            captionText={captionText}
           />
         )}
       </div>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
@@ -23,7 +23,7 @@ import {
   editAudioToolbarComponent$,
   disableAudioSettingsButton$,
 } from './index';
-import { $isAudioNode } from './AudioNode';
+import { $isAudioNode, CaptionKind } from './AudioNode';
 import styles from './styles/audio-plugin.module.css';
 import { AudioTranscript } from './AudioTranscript';
 import { useCellValues } from '@mdxeditor/gurx';
@@ -38,6 +38,8 @@ interface AudioComponentProps {
   captionSrc?: string;
   /** Fetchable caption URL (blob in the builder, relative path in the player). */
   resolvedCaptionSrc?: string;
+  /** Plain-text transcript (when captionKind === 'text'). */
+  captionText?: string;
 }
 
 function AudioComponent({
@@ -47,6 +49,7 @@ function AudioComponent({
   id,
   captionSrc,
   resolvedCaptionSrc,
+  captionText,
 }: AudioComponentProps): JSX.Element {
   const audioRef = React.useRef<HTMLAudioElement | null>(null);
   const [isSelected, setSelected, clearSelection] =
@@ -218,6 +221,8 @@ function AudioComponent({
           muted={false}
           data-audio-id={id}
           data-caption-src={captionSrc}
+          data-caption-kind={captionText ? 'text' : undefined}
+          data-caption-text={captionText}
           style={{
             display: 'block',
             maxWidth: '100%',
@@ -226,11 +231,15 @@ function AudioComponent({
             pointerEvents: 'auto',
           }}
         />
-        {resolvedCaptionSrc && (
-          <AudioTranscript
-            captionSrc={resolvedCaptionSrc}
-            audioRef={audioRef}
-          />
+        {captionText ? (
+          <AudioTranscript text={captionText} audioRef={audioRef} />
+        ) : (
+          resolvedCaptionSrc && (
+            <AudioTranscript
+              captionSrc={resolvedCaptionSrc}
+              audioRef={audioRef}
+            />
+          )
         )}
       </div>
     </React.Suspense>
@@ -245,6 +254,8 @@ export interface AudioEditorProps {
   id: string;
   autoplay: boolean;
   captionSrc?: string;
+  captionKind?: CaptionKind;
+  captionText?: string;
 }
 
 export function AudioEditor({
@@ -255,6 +266,8 @@ export function AudioEditor({
   id,
   autoplay,
   captionSrc,
+  captionKind,
+  captionText,
 }: AudioEditorProps): JSX.Element {
   const [audioFilePath] = useCellValues(audioFilePath$);
   const [Placeholder] = useCellValues(audioPlaceholder$);
@@ -322,6 +335,7 @@ export function AudioEditor({
           id={id}
           captionSrc={captionSrc}
           resolvedCaptionSrc={previewCaptionSrc}
+          captionText={captionKind === 'text' ? captionText : undefined}
         />
         {shouldShowToolbar && (
           <EditAudioToolbar
@@ -332,6 +346,8 @@ export function AudioEditor({
             rest={rest}
             autoplay={autoplay}
             captionSrc={captionSrc}
+            captionKind={captionKind}
+            captionText={captionText}
           />
         )}
       </div>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioNode.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioNode.tsx
@@ -35,11 +35,20 @@ export type SerializedAudioNode = Spread<
     id?: string;
     autoplay?: boolean;
     captionSrc?: string;
+    captionKind?: CaptionKind;
+    captionText?: string;
     type: 'audio';
     version: 1;
   },
   SerializedLexicalNode
 >;
+
+/**
+ * The source of an audio element's transcript: a timed WebVTT file, or a block
+ * of plain text (no timing).
+ * @group Audio
+ */
+export type CaptionKind = 'vtt' | 'text';
 
 /**
  * A lexical node that represents an audio file. Use {@link "$createAudioNode"} to construct one.
@@ -56,6 +65,10 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
   __autoplay: boolean;
   /** @internal */
   __captionSrc: string | undefined;
+  /** @internal */
+  __captionKind: CaptionKind | undefined;
+  /** @internal */
+  __captionText: string | undefined;
 
   /** @internal */
   __rest: (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
@@ -75,6 +88,8 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
       undefined,
       node.__autoplay,
       node.__captionSrc,
+      node.__captionKind,
+      node.__captionText,
     );
     cloned.__id = node.__id;
     return cloned;
@@ -82,7 +97,8 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
 
   /** @internal */
   static override importJSON(serializedNode: SerializedAudioNode): AudioNode {
-    const { title, src, rest, id, autoplay, captionSrc } = serializedNode;
+    const { title, src, rest, id, autoplay, captionSrc, captionKind, captionText } =
+      serializedNode;
     const node = $createAudioNode({
       title,
       src,
@@ -90,6 +106,8 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
       id,
       autoplay,
       captionSrc,
+      captionKind,
+      captionText,
     });
     return node;
   }
@@ -130,6 +148,8 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
     id?: string,
     autoplay?: boolean,
     captionSrc?: string,
+    captionKind?: CaptionKind,
+    captionText?: string,
   ) {
     super(key);
     this.__src = src;
@@ -138,6 +158,8 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
     this.__id = id || this.generateId();
     this.__autoplay = autoplay ?? false;
     this.__captionSrc = captionSrc;
+    this.__captionKind = captionKind;
+    this.__captionText = captionText;
   }
 
   /** @internal */
@@ -159,6 +181,8 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
       id: this.__id,
       autoplay: this.__autoplay,
       captionSrc: this.__captionSrc,
+      captionKind: this.__captionKind,
+      captionText: this.__captionText,
       type: 'audio',
       version: 1,
     };
@@ -226,6 +250,22 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
     this.getWritable().__captionSrc = captionSrc;
   }
 
+  getCaptionKind(): CaptionKind | undefined {
+    return this.__captionKind;
+  }
+
+  setCaptionKind(captionKind: CaptionKind | undefined): void {
+    this.getWritable().__captionKind = captionKind;
+  }
+
+  getCaptionText(): string | undefined {
+    return this.__captionText;
+  }
+
+  setCaptionText(captionText: string | undefined): void {
+    this.getWritable().__captionText = captionText;
+  }
+
   /** @internal */
   shouldBeSerializedAsElement(): boolean {
     // ALWAYS serialize as HTML element to preserve id for animations!
@@ -243,6 +283,8 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
         id={this.__id}
         autoplay={this.__autoplay}
         captionSrc={this.__captionSrc}
+        captionKind={this.__captionKind}
+        captionText={this.__captionText}
       />
     );
   }
@@ -260,6 +302,8 @@ export interface CreateAudioNodeParameters {
   id?: string;
   autoplay?: boolean;
   captionSrc?: string;
+  captionKind?: CaptionKind;
+  captionText?: string;
 }
 
 /**
@@ -268,8 +312,19 @@ export interface CreateAudioNodeParameters {
  * @group Audio
  */
 export function $createAudioNode(params: CreateAudioNodeParameters): AudioNode {
-  const { title, src, key, rest, id, autoplay, captionSrc } = params;
-  return new AudioNode(src, title, rest, key, id, autoplay, captionSrc);
+  const { title, src, key, rest, id, autoplay, captionSrc, captionKind, captionText } =
+    params;
+  return new AudioNode(
+    src,
+    title,
+    rest,
+    key,
+    id,
+    autoplay,
+    captionSrc,
+    captionKind,
+    captionText,
+  );
 }
 
 /**

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioNode.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioNode.tsx
@@ -34,21 +34,22 @@ export type SerializedAudioNode = Spread<
     rest: (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
     id?: string;
     autoplay?: boolean;
+    /**
+     * URL of the transcript/caption file (`.vtt` or `.txt`). The content decides
+     * whether it renders as timed cues or plain text, not the extension.
+     */
     captionSrc?: string;
-    captionKind?: CaptionKind;
+    /**
+     * Back-compat only: inline plain-text transcript from legacy content
+     * (authored before the file-only model). Preserved on round-trip and
+     * rendered read-only, but never produced by the editor anymore.
+     */
     captionText?: string;
     type: 'audio';
     version: 1;
   },
   SerializedLexicalNode
 >;
-
-/**
- * The source of an audio element's transcript: a timed WebVTT file, or a block
- * of plain text (no timing).
- * @group Audio
- */
-export type CaptionKind = 'vtt' | 'text';
 
 /**
  * A lexical node that represents an audio file. Use {@link "$createAudioNode"} to construct one.
@@ -65,9 +66,7 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
   __autoplay: boolean;
   /** @internal */
   __captionSrc: string | undefined;
-  /** @internal */
-  __captionKind: CaptionKind | undefined;
-  /** @internal */
+  /** @internal Back-compat: preserved legacy inline transcript text. */
   __captionText: string | undefined;
 
   /** @internal */
@@ -88,7 +87,6 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
       undefined,
       node.__autoplay,
       node.__captionSrc,
-      node.__captionKind,
       node.__captionText,
     );
     cloned.__id = node.__id;
@@ -97,7 +95,7 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
 
   /** @internal */
   static override importJSON(serializedNode: SerializedAudioNode): AudioNode {
-    const { title, src, rest, id, autoplay, captionSrc, captionKind, captionText } =
+    const { title, src, rest, id, autoplay, captionSrc, captionText } =
       serializedNode;
     const node = $createAudioNode({
       title,
@@ -106,7 +104,6 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
       id,
       autoplay,
       captionSrc,
-      captionKind,
       captionText,
     });
     return node;
@@ -148,7 +145,6 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
     id?: string,
     autoplay?: boolean,
     captionSrc?: string,
-    captionKind?: CaptionKind,
     captionText?: string,
   ) {
     super(key);
@@ -158,7 +154,6 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
     this.__id = id || this.generateId();
     this.__autoplay = autoplay ?? false;
     this.__captionSrc = captionSrc;
-    this.__captionKind = captionKind;
     this.__captionText = captionText;
   }
 
@@ -181,7 +176,6 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
       id: this.__id,
       autoplay: this.__autoplay,
       captionSrc: this.__captionSrc,
-      captionKind: this.__captionKind,
       captionText: this.__captionText,
       type: 'audio',
       version: 1,
@@ -250,20 +244,13 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
     this.getWritable().__captionSrc = captionSrc;
   }
 
-  getCaptionKind(): CaptionKind | undefined {
-    return this.__captionKind;
-  }
-
-  setCaptionKind(captionKind: CaptionKind | undefined): void {
-    this.getWritable().__captionKind = captionKind;
-  }
-
+  /**
+   * Back-compat: legacy inline transcript text. Read-only — the editor no
+   * longer produces inline text (transcripts are files), but existing content
+   * is preserved and still rendered.
+   */
   getCaptionText(): string | undefined {
     return this.__captionText;
-  }
-
-  setCaptionText(captionText: string | undefined): void {
-    this.getWritable().__captionText = captionText;
   }
 
   /** @internal */
@@ -283,7 +270,6 @@ export class AudioNode extends DecoratorNode<JSX.Element> {
         id={this.__id}
         autoplay={this.__autoplay}
         captionSrc={this.__captionSrc}
-        captionKind={this.__captionKind}
         captionText={this.__captionText}
       />
     );
@@ -302,7 +288,7 @@ export interface CreateAudioNodeParameters {
   id?: string;
   autoplay?: boolean;
   captionSrc?: string;
-  captionKind?: CaptionKind;
+  /** Back-compat only: preserved legacy inline transcript text. */
   captionText?: string;
 }
 
@@ -312,7 +298,7 @@ export interface CreateAudioNodeParameters {
  * @group Audio
  */
 export function $createAudioNode(params: CreateAudioNodeParameters): AudioNode {
-  const { title, src, key, rest, id, autoplay, captionSrc, captionKind, captionText } =
+  const { title, src, key, rest, id, autoplay, captionSrc, captionText } =
     params;
   return new AudioNode(
     src,
@@ -322,7 +308,6 @@ export function $createAudioNode(params: CreateAudioNodeParameters): AudioNode {
     id,
     autoplay,
     captionSrc,
-    captionKind,
     captionText,
   );
 }

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
-import { parseVtt, VttCue } from './parseVtt';
+import ClosedCaptionIcon from '@mui/icons-material/ClosedCaption';
+import { parseTranscript, VttCue } from './parseVtt';
 import styles from './styles/audio-plugin.module.css';
 
 interface AudioTranscriptProps {
   /**
-   * URL of the WebVTT caption/transcript file. Used for the timed VTT mode
-   * (highlighting + click-to-seek). Ignored when `text` is provided.
+   * Fetchable URL of the caption file (blob URL in the builder, relative path
+   * in the player). May be a `.vtt` or `.txt` file — the content decides how it
+   * renders (timed cues vs. plain text), not the extension.
    */
   captionSrc?: string;
   /**
-   * Plain-text transcript. When set, the panel renders this static text with
-   * no timing, highlighting, or seeking. Takes precedence over `captionSrc`.
+   * Back-compat only: inline plain-text transcript from legacy content authored
+   * before the file-only model (serialized as `data-caption-text`). Rendered
+   * read-only when no `captionSrc` file is present. The dialog no longer
+   * produces this.
    */
-  text?: string;
+  fallbackText?: string;
   /** Ref to the associated audio element, used for highlighting and seeking. */
   audioRef: React.RefObject<HTMLAudioElement>;
 }
@@ -27,30 +31,57 @@ function formatTime(seconds: number): string {
 }
 
 /**
+ * The visible contents of the transcript toggle: a decorative CC glyph followed
+ * by the label. The icon is `aria-hidden` so the button's accessible name stays
+ * "Show/Hide transcript" and screen readers (e.g. NVDA) announce it as a button
+ * without reading "CC" as stray text.
+ */
+function ToggleLabel({ expanded }: { expanded: boolean }): JSX.Element {
+  return (
+    <>
+      <ClosedCaptionIcon
+        aria-hidden="true"
+        fontSize="small"
+        className={styles.transcriptToggleIcon}
+      />
+      {expanded ? 'Hide transcript' : 'Show transcript'}
+    </>
+  );
+}
+
+/**
  * A transcript panel for an audio element. Audio has no native captions UI, so
- * this fetches the associated WebVTT file, renders it as a collapsible list of
- * cues below the player, highlights the cue matching the current playback time,
- * and lets the learner click a cue to seek the audio to that point.
+ * this fetches the associated caption file and renders it below the player as a
+ * collapsible panel.
+ *
+ * The caption file may be timed WebVTT or plain text. We attempt a VTT parse
+ * and, if it yields cues, render the timed list (highlighting the active cue and
+ * seeking on click); otherwise we render the file's text statically. This lets a
+ * single file picker accept `.vtt` or `.txt` transparently.
  */
 export function AudioTranscript({
   captionSrc,
-  text,
+  fallbackText,
   audioRef,
 }: AudioTranscriptProps): JSX.Element | null {
   const [cues, setCues] = React.useState<VttCue[]>([]);
+  const [text, setText] = React.useState<string>('');
   const [activeIndex, setActiveIndex] = React.useState<number>(-1);
   const [expanded, setExpanded] = React.useState<boolean>(false);
-  const [error, setError] = React.useState<boolean>(false);
 
-  const isText = typeof text === 'string' && text.trim() !== '';
+  const legacyText =
+    typeof fallbackText === 'string' && fallbackText.trim() !== ''
+      ? fallbackText
+      : '';
 
-  // Fetch and parse the VTT whenever the source changes. Skipped in text mode.
+  // Fetch and interpret the caption file whenever the source changes.
   React.useEffect(() => {
     let cancelled = false;
-    setError(false);
     setCues([]);
+    // Default to the legacy inline text (if any) until/unless a file loads.
+    setText(legacyText);
 
-    if (isText || !captionSrc) {
+    if (!captionSrc) {
       return;
     }
 
@@ -61,21 +92,31 @@ export function AudioTranscript({
         }
         return res.text();
       })
-      .then((text) => {
-        if (!cancelled) {
-          setCues(parseVtt(text));
+      .then((raw) => {
+        if (cancelled) {
+          return;
+        }
+        const parsed = parseTranscript(raw);
+        if (parsed.kind === 'vtt') {
+          setCues(parsed.cues);
+          setText('');
+        } else {
+          setCues([]);
+          setText(parsed.text);
         }
       })
       .catch(() => {
+        // Fall back to legacy inline text if the file cannot be loaded.
         if (!cancelled) {
-          setError(true);
+          setCues([]);
+          setText(legacyText);
         }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [captionSrc, isText]);
+  }, [captionSrc, legacyText]);
 
   // Track the active cue against the audio's current time.
   React.useEffect(() => {
@@ -103,29 +144,11 @@ export function AudioTranscript({
     }
   };
 
-  // Plain-text transcript: same collapsible affordance, no timing/seeking.
-  if (isText) {
-    return (
-      <div className={styles.transcriptContainer}>
-        <button
-          type="button"
-          className={styles.transcriptToggle}
-          aria-expanded={expanded}
-          onClick={() => setExpanded((prev) => !prev)}
-        >
-          {expanded ? 'Hide transcript' : 'Show transcript'}
-        </button>
-        {expanded && (
-          <div className={styles.transcriptText} style={{ whiteSpace: 'pre-wrap' }}>
-            {text}
-          </div>
-        )}
-      </div>
-    );
-  }
+  const hasCues = cues.length > 0;
+  const hasText = text.trim() !== '';
 
-  // Nothing to show if the transcript could not be loaded or has no cues.
-  if (error || cues.length === 0) {
+  // Nothing to show if neither a timed transcript nor any text is available.
+  if (!hasCues && !hasText) {
     return null;
   }
 
@@ -137,33 +160,41 @@ export function AudioTranscript({
         aria-expanded={expanded}
         onClick={() => setExpanded((prev) => !prev)}
       >
-        {expanded ? 'Hide transcript' : 'Show transcript'}
+        <ToggleLabel expanded={expanded} />
       </button>
-      {expanded && (
-        <ol className={styles.transcriptList}>
-          {cues.map((cue, index) => (
-            <li
-              key={`${cue.start}-${index}`}
-              className={
-                index === activeIndex
-                  ? `${styles.transcriptCue} ${styles.transcriptCueActive}`
-                  : styles.transcriptCue
-              }
-            >
-              <button
-                type="button"
-                className={styles.transcriptCueButton}
-                onClick={() => handleCueClick(cue)}
+      {expanded &&
+        (hasCues ? (
+          <ol className={styles.transcriptList}>
+            {cues.map((cue, index) => (
+              <li
+                key={`${cue.start}-${index}`}
+                className={
+                  index === activeIndex
+                    ? `${styles.transcriptCue} ${styles.transcriptCueActive}`
+                    : styles.transcriptCue
+                }
               >
-                <span className={styles.transcriptTime}>
-                  {formatTime(cue.start)}
-                </span>
-                <span className={styles.transcriptText}>{cue.text}</span>
-              </button>
-            </li>
-          ))}
-        </ol>
-      )}
+                <button
+                  type="button"
+                  className={styles.transcriptCueButton}
+                  onClick={() => handleCueClick(cue)}
+                >
+                  <span className={styles.transcriptTime}>
+                    {formatTime(cue.start)}
+                  </span>
+                  <span className={styles.transcriptText}>{cue.text}</span>
+                </button>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <div
+            className={styles.transcriptText}
+            style={{ whiteSpace: 'pre-wrap' }}
+          >
+            {text}
+          </div>
+        ))}
     </div>
   );
 }

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
@@ -3,8 +3,16 @@ import { parseVtt, VttCue } from './parseVtt';
 import styles from './styles/audio-plugin.module.css';
 
 interface AudioTranscriptProps {
-  /** URL of the WebVTT caption/transcript file. */
-  captionSrc: string;
+  /**
+   * URL of the WebVTT caption/transcript file. Used for the timed VTT mode
+   * (highlighting + click-to-seek). Ignored when `text` is provided.
+   */
+  captionSrc?: string;
+  /**
+   * Plain-text transcript. When set, the panel renders this static text with
+   * no timing, highlighting, or seeking. Takes precedence over `captionSrc`.
+   */
+  text?: string;
   /** Ref to the associated audio element, used for highlighting and seeking. */
   audioRef: React.RefObject<HTMLAudioElement>;
 }
@@ -26,6 +34,7 @@ function formatTime(seconds: number): string {
  */
 export function AudioTranscript({
   captionSrc,
+  text,
   audioRef,
 }: AudioTranscriptProps): JSX.Element | null {
   const [cues, setCues] = React.useState<VttCue[]>([]);
@@ -33,13 +42,15 @@ export function AudioTranscript({
   const [expanded, setExpanded] = React.useState<boolean>(false);
   const [error, setError] = React.useState<boolean>(false);
 
-  // Fetch and parse the VTT whenever the source changes.
+  const isText = typeof text === 'string' && text.trim() !== '';
+
+  // Fetch and parse the VTT whenever the source changes. Skipped in text mode.
   React.useEffect(() => {
     let cancelled = false;
     setError(false);
     setCues([]);
 
-    if (!captionSrc) {
+    if (isText || !captionSrc) {
       return;
     }
 
@@ -64,7 +75,7 @@ export function AudioTranscript({
     return () => {
       cancelled = true;
     };
-  }, [captionSrc]);
+  }, [captionSrc, isText]);
 
   // Track the active cue against the audio's current time.
   React.useEffect(() => {
@@ -91,6 +102,27 @@ export function AudioTranscript({
       audio.currentTime = cue.start;
     }
   };
+
+  // Plain-text transcript: same collapsible affordance, no timing/seeking.
+  if (isText) {
+    return (
+      <div className={styles.transcriptContainer}>
+        <button
+          type="button"
+          className={styles.transcriptToggle}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          {expanded ? 'Hide transcript' : 'Show transcript'}
+        </button>
+        {expanded && (
+          <div className={styles.transcriptText} style={{ whiteSpace: 'pre-wrap' }}>
+            {text}
+          </div>
+        )}
+      </div>
+    );
+  }
 
   // Nothing to show if the transcript could not be loaded or has no cues.
   if (error || cues.length === 0) {

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/EditAudioToolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/EditAudioToolbar.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { MdxJsxAttribute, MdxJsxExpressionAttribute } from 'mdast-util-mdx-jsx';
 import { openEditAudioDialog$ } from './index';
-import { CaptionKind } from './AudioNode';
 import { usePublisher } from '@mdxeditor/gurx';
 import { IconButton, Tooltip } from '@mui/material';
-import SettingsIcon from '@mui/icons-material/Settings';
 import EditIcon from '@mui/icons-material/Edit';
 
 export interface EditAudioToolbarProps {
@@ -15,8 +13,6 @@ export interface EditAudioToolbarProps {
   rest: (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
   autoplay?: boolean;
   captionSrc?: string;
-  captionKind?: CaptionKind;
-  captionText?: string;
 }
 
 export function EditAudioToolbar({
@@ -27,8 +23,6 @@ export function EditAudioToolbar({
   rest,
   autoplay,
   captionSrc,
-  captionKind,
-  captionText,
 }: EditAudioToolbarProps): JSX.Element {
   const openEditAudioDialog = usePublisher(openEditAudioDialog$);
 
@@ -58,8 +52,6 @@ export function EditAudioToolbar({
                 rest,
                 autoplay,
                 captionSrc,
-                captionKind,
-                captionText,
               },
             });
           }}

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/EditAudioToolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/EditAudioToolbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MdxJsxAttribute, MdxJsxExpressionAttribute } from 'mdast-util-mdx-jsx';
 import { openEditAudioDialog$ } from './index';
+import { CaptionKind } from './AudioNode';
 import { usePublisher } from '@mdxeditor/gurx';
 import { IconButton, Tooltip } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -14,6 +15,8 @@ export interface EditAudioToolbarProps {
   rest: (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
   autoplay?: boolean;
   captionSrc?: string;
+  captionKind?: CaptionKind;
+  captionText?: string;
 }
 
 export function EditAudioToolbar({
@@ -24,6 +27,8 @@ export function EditAudioToolbar({
   rest,
   autoplay,
   captionSrc,
+  captionKind,
+  captionText,
 }: EditAudioToolbarProps): JSX.Element {
   const openEditAudioDialog = usePublisher(openEditAudioDialog$);
 
@@ -53,6 +58,8 @@ export function EditAudioToolbar({
                 rest,
                 autoplay,
                 captionSrc,
+                captionKind,
+                captionText,
               },
             });
           }}

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/LexicalAudioVisitor.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/LexicalAudioVisitor.ts
@@ -38,8 +38,17 @@ export const LexicalAudioVisitor: LexicalExportVisitor<AudioNode, Mdast.Html> =
         }
       }
 
+      // Transcript: either a timed VTT file (data-caption-src) or a block of
+      // plain text (data-caption-text). Emit exactly one. `setAttribute`
+      // handles escaping of quotes/newlines in the text value.
+      const captionKind = lexicalNode.getCaptionKind();
+      const captionText = lexicalNode.getCaptionText();
       const captionSrc = lexicalNode.getCaptionSrc();
-      if (captionSrc) {
+      if (captionKind === 'text' && captionText) {
+        audio.setAttribute('data-caption-kind', 'text');
+        audio.setAttribute('data-caption-text', captionText);
+      } else if (captionSrc) {
+        // Default / 'vtt': preserve the existing data-caption-src contract.
         audio.setAttribute('data-caption-src', captionSrc);
       }
 

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/LexicalAudioVisitor.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/LexicalAudioVisitor.ts
@@ -38,18 +38,19 @@ export const LexicalAudioVisitor: LexicalExportVisitor<AudioNode, Mdast.Html> =
         }
       }
 
-      // Transcript: either a timed VTT file (data-caption-src) or a block of
-      // plain text (data-caption-text). Emit exactly one. `setAttribute`
-      // handles escaping of quotes/newlines in the text value.
-      const captionKind = lexicalNode.getCaptionKind();
-      const captionText = lexicalNode.getCaptionText();
+      // Transcript is a caption file (`.vtt` or `.txt`) referenced by
+      // data-caption-src; its content decides timed-vs-plain at render time.
       const captionSrc = lexicalNode.getCaptionSrc();
-      if (captionKind === 'text' && captionText) {
-        audio.setAttribute('data-caption-kind', 'text');
-        audio.setAttribute('data-caption-text', captionText);
-      } else if (captionSrc) {
-        // Default / 'vtt': preserve the existing data-caption-src contract.
+      if (captionSrc) {
         audio.setAttribute('data-caption-src', captionSrc);
+      }
+
+      // Back-compat: legacy content authored with inline text (no file) is
+      // round-tripped so re-saving never drops an existing transcript. The
+      // editor no longer produces this attribute for new content.
+      const captionText = lexicalNode.getCaptionText();
+      if (!captionSrc && captionText) {
+        audio.setAttribute('data-caption-text', captionText);
       }
 
       actions.appendToParent(mdastParent, {

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/MdastAudioVisitor.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/MdastAudioVisitor.ts
@@ -35,13 +35,9 @@ export const MdastHtmlAudioVisitor: MdastImportVisitor<Mdast.Html> = {
     const id = audio.getAttribute('data-audio-id') || undefined;
     const autoplay = audio.hasAttribute('autoplay');
     const captionSrc = audio.getAttribute('data-caption-src') || undefined;
+    // Back-compat: legacy inline transcript text (no file). Preserved and
+    // rendered read-only; the editor no longer produces it.
     const captionText = audio.getAttribute('data-caption-text') || undefined;
-    const captionKind =
-      audio.getAttribute('data-caption-kind') === 'text' || captionText
-        ? 'text'
-        : captionSrc
-          ? 'vtt'
-          : undefined;
 
     const audioNode = $createAudioNode({
       src: src || '',
@@ -49,7 +45,6 @@ export const MdastHtmlAudioVisitor: MdastImportVisitor<Mdast.Html> = {
       id,
       autoplay,
       captionSrc,
-      captionKind,
       captionText,
     });
 
@@ -84,13 +79,8 @@ export const MdastJsxAudioVisitor: MdastImportVisitor<
     const autoplayAttr = getAttributeValue(mdastNode, 'autoplay');
     const autoplay = autoplayAttr !== undefined;
     const captionSrc = getAttributeValue(mdastNode, 'data-caption-src');
+    // Back-compat: legacy inline transcript text (no file).
     const captionText = getAttributeValue(mdastNode, 'data-caption-text');
-    const captionKind =
-      getAttributeValue(mdastNode, 'data-caption-kind') === 'text' || captionText
-        ? 'text'
-        : captionSrc
-          ? 'vtt'
-          : undefined;
 
     const rest = mdastNode.attributes.filter((a) => {
       return (
@@ -116,7 +106,6 @@ export const MdastJsxAudioVisitor: MdastImportVisitor<
       id,
       autoplay,
       captionSrc: captionSrc || undefined,
-      captionKind,
       captionText: captionText || undefined,
     });
 

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/MdastAudioVisitor.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/MdastAudioVisitor.ts
@@ -35,6 +35,13 @@ export const MdastHtmlAudioVisitor: MdastImportVisitor<Mdast.Html> = {
     const id = audio.getAttribute('data-audio-id') || undefined;
     const autoplay = audio.hasAttribute('autoplay');
     const captionSrc = audio.getAttribute('data-caption-src') || undefined;
+    const captionText = audio.getAttribute('data-caption-text') || undefined;
+    const captionKind =
+      audio.getAttribute('data-caption-kind') === 'text' || captionText
+        ? 'text'
+        : captionSrc
+          ? 'vtt'
+          : undefined;
 
     const audioNode = $createAudioNode({
       src: src || '',
@@ -42,6 +49,8 @@ export const MdastHtmlAudioVisitor: MdastImportVisitor<Mdast.Html> = {
       id,
       autoplay,
       captionSrc,
+      captionKind,
+      captionText,
     });
 
     if (lexicalParent.getType() === 'root') {
@@ -75,11 +84,28 @@ export const MdastJsxAudioVisitor: MdastImportVisitor<
     const autoplayAttr = getAttributeValue(mdastNode, 'autoplay');
     const autoplay = autoplayAttr !== undefined;
     const captionSrc = getAttributeValue(mdastNode, 'data-caption-src');
+    const captionText = getAttributeValue(mdastNode, 'data-caption-text');
+    const captionKind =
+      getAttributeValue(mdastNode, 'data-caption-kind') === 'text' || captionText
+        ? 'text'
+        : captionSrc
+          ? 'vtt'
+          : undefined;
 
     const rest = mdastNode.attributes.filter((a) => {
       return (
         a.type === 'mdxJsxAttribute' &&
-        !['src', 'title', 'controls', 'data-audio-id', 'data-caption-src', 'autoplay', 'muted'].includes(a.name)
+        ![
+          'src',
+          'title',
+          'controls',
+          'data-audio-id',
+          'data-caption-src',
+          'data-caption-kind',
+          'data-caption-text',
+          'autoplay',
+          'muted',
+        ].includes(a.name)
       );
     });
 
@@ -90,6 +116,8 @@ export const MdastJsxAudioVisitor: MdastImportVisitor<
       id,
       autoplay,
       captionSrc: captionSrc || undefined,
+      captionKind,
+      captionText: captionText || undefined,
     });
 
     if (lexicalParent.getType() === 'root') {

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/index.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/index.ts
@@ -33,7 +33,6 @@ import {
   $createAudioNode,
   CreateAudioNodeParameters,
   AudioNode,
-  CaptionKind,
 } from './AudioNode';
 import { LexicalAudioVisitor } from './LexicalAudioVisitor';
 import {
@@ -73,9 +72,8 @@ export interface SrcAudioParameters extends BaseAudioParameters {
   src: string;
   rest?: (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
   autoplay?: boolean;
+  /** Caption file path (`.vtt` or `.txt`); content decides how it renders. */
   captionSrc?: string;
-  captionKind?: CaptionKind;
-  captionText?: string;
 }
 
 /**
@@ -91,10 +89,10 @@ export interface SaveAudioParameters extends BaseAudioParameters {
   file?: FileList;
   rest?: (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
   autoplay?: boolean;
+  /** Existing caption file path (`.vtt` or `.txt`) chosen from the picker. */
   captionSrc?: string;
+  /** Newly uploaded caption file to persist before saving. */
   captionFile?: FileList;
-  captionKind?: CaptionKind;
-  captionText?: string;
 }
 
 /**
@@ -134,8 +132,6 @@ const internalInsertAudio$ = Signal<SrcAudioParameters>((r) => {
           rest: values.rest ?? [],
           autoplay: values.autoplay,
           captionSrc: values.captionSrc,
-          captionKind: values.captionKind,
-          captionText: values.captionText,
         });
         $insertNodes([audioNode]);
         if ($isRootOrShadowRoot(audioNode.getParentOrThrow())) {
@@ -207,19 +203,9 @@ export const audioDialogState$ = Cell<
       withLatestFrom(activeEditor$, audioUploadHandler$, audioDialogState$),
     ),
     ([values, theEditor, audioUploadHandler, dialogState]) => {
-      // The transcript is one of two mutually exclusive kinds. Normalize here so
-      // exactly one of captionSrc / captionText is ever stored on the node.
-      const isText = values.captionKind === 'text';
-
+      // The transcript is a single caption file (`.vtt` or `.txt`), referenced
+      // by captionSrc. Its content decides timed-vs-plain at render time.
       const applyAudioNode = (src: string, captionSrc: string | undefined) => {
-        const captionKind: CaptionKind | undefined = isText
-          ? 'text'
-          : captionSrc
-            ? 'vtt'
-            : undefined;
-        const captionText = isText ? values.captionText : undefined;
-        const resolvedCaptionSrc = isText ? undefined : captionSrc;
-
         if (dialogState.type === 'editing') {
           theEditor?.update(() => {
             const { nodeKey } = dialogState;
@@ -229,28 +215,23 @@ export const audioDialogState$ = Cell<
             audioNode.setSrc(src);
             audioNode.setRest(values.rest);
             audioNode.setAutoplay(values.autoplay ?? false);
-            audioNode.setCaptionSrc(resolvedCaptionSrc);
-            audioNode.setCaptionKind(captionKind);
-            audioNode.setCaptionText(captionText);
+            audioNode.setCaptionSrc(captionSrc);
           });
           r.pub(audioDialogState$, { type: 'inactive' });
         } else {
           r.pub(internalInsertAudio$, {
             ...values,
             src,
-            captionSrc: resolvedCaptionSrc,
-            captionKind,
-            captionText,
+            captionSrc,
           });
           r.pub(audioDialogState$, { type: 'inactive' });
         }
       };
 
       const resolveCaption = async (src: string) => {
-        // Plain-text transcripts have no file to upload.
-        if (isText) {
-          applyAudioNode(src, undefined);
-        } else if (
+        // A newly uploaded caption file must be persisted first; otherwise use
+        // the path already chosen in the picker (which may be empty).
+        if (
           values.captionFile &&
           values.captionFile.length > 0 &&
           audioUploadHandler
@@ -258,7 +239,7 @@ export const audioDialogState$ = Cell<
           const captionSrc = await audioUploadHandler(values.captionFile.item(0)!);
           applyAudioNode(src, captionSrc);
         } else {
-          applyAudioNode(src, values.captionSrc);
+          applyAudioNode(src, values.captionSrc || undefined);
         }
       };
 

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/index.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/index.ts
@@ -33,6 +33,7 @@ import {
   $createAudioNode,
   CreateAudioNodeParameters,
   AudioNode,
+  CaptionKind,
 } from './AudioNode';
 import { LexicalAudioVisitor } from './LexicalAudioVisitor';
 import {
@@ -73,6 +74,8 @@ export interface SrcAudioParameters extends BaseAudioParameters {
   rest?: (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
   autoplay?: boolean;
   captionSrc?: string;
+  captionKind?: CaptionKind;
+  captionText?: string;
 }
 
 /**
@@ -90,6 +93,8 @@ export interface SaveAudioParameters extends BaseAudioParameters {
   autoplay?: boolean;
   captionSrc?: string;
   captionFile?: FileList;
+  captionKind?: CaptionKind;
+  captionText?: string;
 }
 
 /**
@@ -129,6 +134,8 @@ const internalInsertAudio$ = Signal<SrcAudioParameters>((r) => {
           rest: values.rest ?? [],
           autoplay: values.autoplay,
           captionSrc: values.captionSrc,
+          captionKind: values.captionKind,
+          captionText: values.captionText,
         });
         $insertNodes([audioNode]);
         if ($isRootOrShadowRoot(audioNode.getParentOrThrow())) {
@@ -200,7 +207,19 @@ export const audioDialogState$ = Cell<
       withLatestFrom(activeEditor$, audioUploadHandler$, audioDialogState$),
     ),
     ([values, theEditor, audioUploadHandler, dialogState]) => {
+      // The transcript is one of two mutually exclusive kinds. Normalize here so
+      // exactly one of captionSrc / captionText is ever stored on the node.
+      const isText = values.captionKind === 'text';
+
       const applyAudioNode = (src: string, captionSrc: string | undefined) => {
+        const captionKind: CaptionKind | undefined = isText
+          ? 'text'
+          : captionSrc
+            ? 'vtt'
+            : undefined;
+        const captionText = isText ? values.captionText : undefined;
+        const resolvedCaptionSrc = isText ? undefined : captionSrc;
+
         if (dialogState.type === 'editing') {
           theEditor?.update(() => {
             const { nodeKey } = dialogState;
@@ -210,17 +229,32 @@ export const audioDialogState$ = Cell<
             audioNode.setSrc(src);
             audioNode.setRest(values.rest);
             audioNode.setAutoplay(values.autoplay ?? false);
-            audioNode.setCaptionSrc(captionSrc);
+            audioNode.setCaptionSrc(resolvedCaptionSrc);
+            audioNode.setCaptionKind(captionKind);
+            audioNode.setCaptionText(captionText);
           });
           r.pub(audioDialogState$, { type: 'inactive' });
         } else {
-          r.pub(internalInsertAudio$, { ...values, src, captionSrc });
+          r.pub(internalInsertAudio$, {
+            ...values,
+            src,
+            captionSrc: resolvedCaptionSrc,
+            captionKind,
+            captionText,
+          });
           r.pub(audioDialogState$, { type: 'inactive' });
         }
       };
 
       const resolveCaption = async (src: string) => {
-        if (values.captionFile && values.captionFile.length > 0 && audioUploadHandler) {
+        // Plain-text transcripts have no file to upload.
+        if (isText) {
+          applyAudioNode(src, undefined);
+        } else if (
+          values.captionFile &&
+          values.captionFile.length > 0 &&
+          audioUploadHandler
+        ) {
           const captionSrc = await audioUploadHandler(values.captionFile.item(0)!);
           applyAudioNode(src, captionSrc);
         } else {

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/parseVtt.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/parseVtt.ts
@@ -87,3 +87,32 @@ export function parseVtt(vtt: string): VttCue[] {
 
   return cues;
 }
+
+/**
+ * The result of interpreting a caption file, regardless of extension. A caption
+ * file is timed VTT if it parses into at least one cue; otherwise it is treated
+ * as a plain-text transcript. This lets a single file picker accept `.vtt` or
+ * `.txt` (or a mislabeled file) and do the right thing by content, not name.
+ */
+export type ParsedTranscript =
+  | { kind: 'vtt'; cues: VttCue[] }
+  | { kind: 'text'; text: string };
+
+/**
+ * Interprets raw caption file contents as either timed VTT or plain text.
+ *
+ * The rule is content-based, not extension-based: we attempt a VTT parse and,
+ * if it yields at least one cue, treat the file as timed VTT. Anything that
+ * produces no cues — a `.txt` transcript, a mislabeled file, or a `.vtt` with
+ * no valid timing — falls back to plain text so its content is never dropped.
+ */
+export function parseTranscript(raw: string): ParsedTranscript {
+  const cues = parseVtt(raw);
+  if (cues.length > 0) {
+    return { kind: 'vtt', cues };
+  }
+  // Strip a leading `WEBVTT` header line if present, so a header-only or
+  // cue-less VTT doesn't show its boilerplate as transcript text.
+  const text = raw.replace(/^﻿?WEBVTT[^\n]*\n?/, '').trim();
+  return { kind: 'text', text };
+}

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/styles/audio-plugin.module.css
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/styles/audio-plugin.module.css
@@ -24,6 +24,9 @@
 }
 
 .transcriptToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   background: none;
   border: none;
   padding: 4px 0;
@@ -35,6 +38,11 @@
 
 .transcriptToggle:hover {
   text-decoration: underline;
+}
+
+.transcriptToggleIcon {
+  /* Match the icon to the label's cap height rather than the MUI default. */
+  font-size: 1.15rem;
 }
 
 .transcriptList {

--- a/packages/ui/src/lib/cmi5/markdown/MarkDownParser.tsx
+++ b/packages/ui/src/lib/cmi5/markdown/MarkDownParser.tsx
@@ -21,6 +21,7 @@ import MarkdownImage from './MarkdownImage';
 import { SlideEvent } from './constants/SlideEvents';
 import MDTextEffects from './components/MDTextEffects';
 import MDAnimation from './components/MDAnimation';
+import MDAudio from './components/MDAudio';
 import { AuContextProps } from '@rapid-cmi5/cmi5-build-common';
 
 /**
@@ -269,6 +270,10 @@ export const customMarkdownParser = (
 
     a: (props: any) => {
       return parseYoutubeLinks(props);
+    },
+
+    audio: (props: any) => {
+      return <MDAudio {...props} auProps={auProps} />;
     },
 
     table: (props: any) => {

--- a/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
+++ b/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import { AuContextProps } from '@rapid-cmi5/cmi5-build-common';
+
+/**
+ * A single parsed WebVTT cue.
+ */
+interface VttCue {
+  /** Start time in seconds. */
+  start: number;
+  /** End time in seconds. */
+  end: number;
+  /** Cue text. */
+  text: string;
+}
+
+/**
+ * Converts a WebVTT timestamp (`HH:MM:SS.mmm` or `MM:SS.mmm`) into seconds.
+ * Returns `NaN` if the timestamp cannot be parsed.
+ */
+function timestampToSeconds(timestamp: string): number {
+  const parts = timestamp.trim().split(':');
+  if (parts.length < 2 || parts.length > 3) {
+    return NaN;
+  }
+  const seconds = parts.map((p) => Number(p.replace(',', '.')));
+  if (seconds.some((n) => Number.isNaN(n))) {
+    return NaN;
+  }
+  if (seconds.length === 3) {
+    const [h, m, s] = seconds;
+    return h * 3600 + m * 60 + s;
+  }
+  const [m, s] = seconds;
+  return m * 60 + s;
+}
+
+/**
+ * Parses WebVTT text into an ordered list of timed cues. Cue settings and
+ * identifiers are ignored — only timing and text are retained.
+ */
+function parseVtt(vtt: string): VttCue[] {
+  const cues: VttCue[] = [];
+  const blocks = vtt.replace(/\r\n?/g, '\n').split(/\n\n+/);
+
+  for (const block of blocks) {
+    const lines = block.split('\n').filter((line) => line.trim() !== '');
+    if (lines.length === 0) {
+      continue;
+    }
+    const arrowIndex = lines.findIndex((line) => line.includes('-->'));
+    if (arrowIndex === -1) {
+      continue;
+    }
+    const [startRaw, endRaw] = lines[arrowIndex].split('-->');
+    if (!startRaw || !endRaw) {
+      continue;
+    }
+    const start = timestampToSeconds(startRaw);
+    const end = timestampToSeconds(endRaw.trim().split(/\s+/)[0]);
+    if (Number.isNaN(start) || Number.isNaN(end)) {
+      continue;
+    }
+    const text = lines
+      .slice(arrowIndex + 1)
+      .map((line) => line.replace(/<[^>]+>/g, ''))
+      .join('\n')
+      .trim();
+    if (text === '') {
+      continue;
+    }
+    cues.push({ start, end, text });
+  }
+  return cues;
+}
+
+/**
+ * Formats seconds as `M:SS`.
+ */
+function formatTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Reads the value of a hast property, accounting for react-markdown's camelCase
+ * conversion of `data-*` attributes.
+ */
+function prop(
+  node: { properties?: Record<string, unknown> } | undefined,
+  ...keys: string[]
+): string | undefined {
+  const properties = node?.properties;
+  if (!properties) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = properties[key];
+    if (typeof value === 'string' && value !== '') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Player-side renderer for `<audio>` elements in course content.
+ *
+ * Audio has no native captions UI, so this renders the native player followed
+ * by an optional collapsible transcript panel. The transcript comes from one of
+ * two sources serialized onto the element by the editor:
+ *  - `data-caption-src`: a WebVTT file (timed; highlights the active cue and
+ *    seeks the audio on cue click).
+ *  - `data-caption-text`: a block of plain text (static, no timing).
+ *
+ * The native `data-audio-id` / `src` / `autoplay` / inline styles are preserved
+ * so existing playback + LRS tracking (MediaEventManager) keep working.
+ */
+export default function MDAudio(
+  props: { node: any; auProps?: AuContextProps } & Record<string, unknown>,
+): JSX.Element {
+  const { node, auProps } = props;
+
+  const rawSrc = prop(node, 'src');
+  const title = prop(node, 'title');
+  const audioId = prop(node, 'dataAudioId', 'data-audio-id');
+  const rawCaptionSrc = prop(node, 'dataCaptionSrc', 'data-caption-src');
+  const captionText = prop(node, 'dataCaptionText', 'data-caption-text');
+  const autoplay =
+    node?.properties?.autoplay !== undefined &&
+    node?.properties?.autoplay !== false;
+
+  const audioRef = React.useRef<HTMLAudioElement>(null);
+  const [cues, setCues] = React.useState<VttCue[]>([]);
+  const [activeIndex, setActiveIndex] = React.useState<number>(-1);
+  const [expanded, setExpanded] = React.useState<boolean>(false);
+  // Resolved (fetchable) URLs. Relative course paths must be turned into blob
+  // URLs via getLocalImage — the same generic file resolver used for images.
+  const [src, setSrc] = React.useState<string | undefined>(rawSrc);
+  const [captionSrc, setCaptionSrc] = React.useState<string | undefined>(
+    rawCaptionSrc,
+  );
+
+  const isText = typeof captionText === 'string' && captionText.trim() !== '';
+
+  // Resolve relative course paths to blob URLs (mirrors MarkdownImage).
+  React.useEffect(() => {
+    const isRelative = (p?: string) =>
+      typeof p === 'string' && (p.startsWith('./') || p.startsWith('../'));
+    const auPath = auProps?.au?.dirPath;
+    if (!auProps?.getLocalImage || !auPath) {
+      return;
+    }
+    if (isRelative(rawSrc)) {
+      auProps.getLocalImage(rawSrc as string, auPath).then((blob) => {
+        if (blob) setSrc(blob);
+      });
+    }
+    if (!isText && isRelative(rawCaptionSrc)) {
+      auProps.getLocalImage(rawCaptionSrc as string, auPath).then((blob) => {
+        if (blob) setCaptionSrc(blob);
+      });
+    }
+  }, [rawSrc, rawCaptionSrc, isText, auProps]);
+
+  // Fetch + parse VTT (skipped in text mode).
+  React.useEffect(() => {
+    let cancelled = false;
+    setCues([]);
+    if (isText || !captionSrc) {
+      return;
+    }
+    fetch(captionSrc)
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to load transcript: ${res.status}`);
+        }
+        return res.text();
+      })
+      .then((text) => {
+        if (!cancelled) {
+          setCues(parseVtt(text));
+        }
+      })
+      .catch(() => {
+        /* no transcript panel if it cannot be loaded */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [captionSrc, isText]);
+
+  // Highlight the active cue as the audio plays.
+  React.useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || cues.length === 0) {
+      return;
+    }
+    const onTimeUpdate = () => {
+      const t = audio.currentTime;
+      setActiveIndex(cues.findIndex((cue) => t >= cue.start && t < cue.end));
+    };
+    audio.addEventListener('timeupdate', onTimeUpdate);
+    return () => audio.removeEventListener('timeupdate', onTimeUpdate);
+  }, [cues]);
+
+  const hasTranscript = isText || cues.length > 0;
+
+  return (
+    <span style={{ display: 'block' }}>
+      <audio
+        ref={audioRef}
+        src={src}
+        title={title}
+        controls
+        autoPlay={autoplay}
+        data-audio-id={audioId}
+        style={{ display: 'block', width: '100%' }}
+      />
+      {hasTranscript && (
+        <span style={{ display: 'block', marginTop: 4 }}>
+          <button
+            type="button"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((prev) => !prev)}
+            style={{
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              textDecoration: 'underline',
+              font: 'inherit',
+            }}
+          >
+            {expanded ? 'Hide transcript' : 'Show transcript'}
+          </button>
+          {expanded &&
+            (isText ? (
+              <span
+                style={{ display: 'block', whiteSpace: 'pre-wrap', marginTop: 4 }}
+              >
+                {captionText}
+              </span>
+            ) : (
+              <ol style={{ listStyle: 'none', padding: 0, marginTop: 4 }}>
+                {cues.map((cue, index) => (
+                  <li key={`${cue.start}-${index}`}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (audioRef.current) {
+                          audioRef.current.currentTime = cue.start;
+                        }
+                      }}
+                      style={{
+                        display: 'flex',
+                        gap: 8,
+                        background:
+                          index === activeIndex
+                            ? 'rgba(60, 132, 244, 0.15)'
+                            : 'none',
+                        border: 'none',
+                        padding: '2px 4px',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        font: 'inherit',
+                        width: '100%',
+                      }}
+                    >
+                      <span style={{ opacity: 0.6, minWidth: 40 }}>
+                        {formatTime(cue.start)}
+                      </span>
+                      <span>{cue.text}</span>
+                    </button>
+                  </li>
+                ))}
+              </ol>
+            ))}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
+++ b/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ClosedCaptionIcon from '@mui/icons-material/ClosedCaption';
 import { AuContextProps } from '@rapid-cmi5/cmi5-build-common';
 
 /**
@@ -74,6 +75,30 @@ function parseVtt(vtt: string): VttCue[] {
 }
 
 /**
+ * The result of interpreting a caption file, regardless of extension: timed VTT
+ * cues, or a block of plain text.
+ */
+type ParsedTranscript =
+  | { kind: 'vtt'; cues: VttCue[] }
+  | { kind: 'text'; text: string };
+
+/**
+ * Interprets raw caption file contents as either timed VTT or plain text. The
+ * rule is content-based, not extension-based: attempt a VTT parse and, if it
+ * yields at least one cue, treat the file as timed VTT; otherwise fall back to
+ * plain text so a `.txt`, mislabeled, or cue-less file is never dropped.
+ */
+function parseTranscript(raw: string): ParsedTranscript {
+  const cues = parseVtt(raw);
+  if (cues.length > 0) {
+    return { kind: 'vtt', cues };
+  }
+  // Strip a leading `WEBVTT` header line so header-only files don't leak it.
+  const text = raw.replace(/^﻿?WEBVTT[^\n]*\n?/, '').trim();
+  return { kind: 'text', text };
+}
+
+/**
  * Formats seconds as `M:SS`.
  */
 function formatTime(seconds: number): string {
@@ -125,13 +150,16 @@ export default function MDAudio(
   const title = prop(node, 'title');
   const audioId = prop(node, 'dataAudioId', 'data-audio-id');
   const rawCaptionSrc = prop(node, 'dataCaptionSrc', 'data-caption-src');
-  const captionText = prop(node, 'dataCaptionText', 'data-caption-text');
+  // Back-compat: legacy inline transcript text (content authored before the
+  // file-only model). Rendered read-only when no caption file is present.
+  const legacyText = prop(node, 'dataCaptionText', 'data-caption-text') ?? '';
   const autoplay =
     node?.properties?.autoplay !== undefined &&
     node?.properties?.autoplay !== false;
 
   const audioRef = React.useRef<HTMLAudioElement>(null);
   const [cues, setCues] = React.useState<VttCue[]>([]);
+  const [text, setText] = React.useState<string>(legacyText);
   const [activeIndex, setActiveIndex] = React.useState<number>(-1);
   const [expanded, setExpanded] = React.useState<boolean>(false);
   // Resolved (fetchable) URLs. Relative course paths must be turned into blob
@@ -140,8 +168,6 @@ export default function MDAudio(
   const [captionSrc, setCaptionSrc] = React.useState<string | undefined>(
     rawCaptionSrc,
   );
-
-  const isText = typeof captionText === 'string' && captionText.trim() !== '';
 
   // Resolve relative course paths to blob URLs (mirrors MarkdownImage).
   React.useEffect(() => {
@@ -156,18 +182,20 @@ export default function MDAudio(
         if (blob) setSrc(blob);
       });
     }
-    if (!isText && isRelative(rawCaptionSrc)) {
+    if (isRelative(rawCaptionSrc)) {
       auProps.getLocalImage(rawCaptionSrc as string, auPath).then((blob) => {
         if (blob) setCaptionSrc(blob);
       });
     }
-  }, [rawSrc, rawCaptionSrc, isText, auProps]);
+  }, [rawSrc, rawCaptionSrc, auProps]);
 
-  // Fetch + parse VTT (skipped in text mode).
+  // Fetch the caption file and interpret it as timed VTT or plain text. Falls
+  // back to any legacy inline text if there is no file or it cannot be loaded.
   React.useEffect(() => {
     let cancelled = false;
     setCues([]);
-    if (isText || !captionSrc) {
+    setText(legacyText);
+    if (!captionSrc) {
       return;
     }
     fetch(captionSrc)
@@ -177,18 +205,26 @@ export default function MDAudio(
         }
         return res.text();
       })
-      .then((text) => {
-        if (!cancelled) {
-          setCues(parseVtt(text));
+      .then((raw) => {
+        if (cancelled) {
+          return;
+        }
+        const parsed = parseTranscript(raw);
+        if (parsed.kind === 'vtt') {
+          setCues(parsed.cues);
+          setText('');
+        } else {
+          setCues([]);
+          setText(parsed.text);
         }
       })
       .catch(() => {
-        /* no transcript panel if it cannot be loaded */
+        /* keep the legacy-text fallback if the file cannot be loaded */
       });
     return () => {
       cancelled = true;
     };
-  }, [captionSrc, isText]);
+  }, [captionSrc, legacyText]);
 
   // Highlight the active cue as the audio plays.
   React.useEffect(() => {
@@ -204,7 +240,13 @@ export default function MDAudio(
     return () => audio.removeEventListener('timeupdate', onTimeUpdate);
   }, [cues]);
 
-  const hasTranscript = isText || cues.length > 0;
+  const hasCues = cues.length > 0;
+  const hasText = text.trim() !== '';
+  const hasTranscript = hasCues || hasText;
+  // Stable id linking the toggle button to the transcript panel it controls, so
+  // assistive tech can associate the two (WCAG 1.2.1 / 1.2.3: the transcript is
+  // the text alternative for this audio-only content and must be discoverable).
+  const panelId = React.useId();
 
   return (
     <span style={{ display: 'block' }}>
@@ -212,6 +254,7 @@ export default function MDAudio(
         ref={audioRef}
         src={src}
         title={title}
+        aria-label={title || 'Audio'}
         controls
         autoPlay={autoplay}
         data-audio-id={audioId}
@@ -222,8 +265,12 @@ export default function MDAudio(
           <button
             type="button"
             aria-expanded={expanded}
+            aria-controls={panelId}
             onClick={() => setExpanded((prev) => !prev)}
             style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
               background: 'none',
               border: 'none',
               padding: 0,
@@ -232,18 +279,22 @@ export default function MDAudio(
               font: 'inherit',
             }}
           >
+            {/* Decorative CC glyph — hidden from assistive tech so the button's
+                accessible name stays "Show/Hide transcript" and NVDA announces
+                it as a button, not "CC Show transcript". */}
+            <ClosedCaptionIcon aria-hidden="true" style={{ fontSize: '1.1em' }} />
             {expanded ? 'Hide transcript' : 'Show transcript'}
           </button>
-          {expanded &&
-            (isText ? (
-              <span
-                style={{ display: 'block', whiteSpace: 'pre-wrap', marginTop: 4 }}
-              >
-                {captionText}
-              </span>
-            ) : (
-              <ol style={{ listStyle: 'none', padding: 0, marginTop: 4 }}>
-                {cues.map((cue, index) => (
+          {expanded && (
+            <span
+              id={panelId}
+              role="region"
+              aria-label="Transcript"
+              style={{ display: 'block' }}
+            >
+              {hasCues ? (
+                <ol style={{ listStyle: 'none', padding: 0, marginTop: 4 }}>
+                  {cues.map((cue, index) => (
                   <li key={`${cue.start}-${index}`}>
                     <button
                       type="button"
@@ -273,9 +324,21 @@ export default function MDAudio(
                       <span>{cue.text}</span>
                     </button>
                   </li>
-                ))}
-              </ol>
-            ))}
+                  ))}
+                </ol>
+              ) : (
+                <span
+                  style={{
+                    display: 'block',
+                    whiteSpace: 'pre-wrap',
+                    marginTop: 4,
+                  }}
+                >
+                  {text}
+                </span>
+              )}
+            </span>
+          )}
         </span>
       )}
     </span>


### PR DESCRIPTION
Add support for showing static text (already have vtt support) to audio element Fix previewing issue if test file didn't already exist

<img width="2525" height="1228" alt="audiotext" src="https://github.com/user-attachments/assets/2bfa5b40-88a6-48b7-b754-0e5adbbe3e0f" />
