### PR TITLE
fix: fix incorrect 'clickable' status on component hierarchies  (CCUI-3050)

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/player/plugins/aria-override/ariaOverridePlugin.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/aria-override/ariaOverridePlugin.tsx
@@ -7,57 +7,135 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import { useEffect } from 'react';
 
 /**
+ * Attributes Lexical stamps onto editor roots / decorator nodes that make NVDA
+ * announce non-interactive content as "clickable" or treat it as a form field.
+ *
+ * NVDA keys off the *presence* of `contenteditable` (even `="false"`), so the
+ * attribute must be removed outright — changing `role` alone is NOT enough
+ * (verified: grid cells carry role="none" and still leak while contenteditable
+ * remains).
+ */
+function neutralizeElement(el: HTMLElement): void {
+  // contenteditable="false" — the primary "clickable" trigger. Lexical hardcodes
+  // this on the editor root AND on every decorator node during reconciliation
+  // (lexical: "Decorators are always non editable"). Remove it wherever present.
+  if (el.getAttribute('contenteditable') === 'false') {
+    el.removeAttribute('contenteditable');
+  }
+
+  // role="textbox" — incorrect role for a read-only content region.
+  if (el.getAttribute('role') === 'textbox') {
+    el.removeAttribute('role');
+  }
+
+  // aria-readonly — implies textbox semantics even without the role.
+  if (el.hasAttribute('aria-readonly')) {
+    el.removeAttribute('aria-readonly');
+  }
+
+  // aria-autocomplete — only valid on combobox/textbox/list inputs.
+  if (el.hasAttribute('aria-autocomplete')) {
+    el.removeAttribute('aria-autocomplete');
+  }
+
+  // aria-label="editable markdown" — wrong context for a content consumer.
+  if (el.getAttribute('aria-label') === 'editable markdown') {
+    el.removeAttribute('aria-label');
+  }
+}
+
+/**
+ * Neutralize the given root and every descendant that carries contenteditable.
+ * Covers Source 1 (the Lexical editor root) and Source 2 (decorator nodes),
+ * which registerRootListener alone can never reach.
+ */
+function neutralizeSubtree(root: HTMLElement): void {
+  neutralizeElement(root);
+  root
+    .querySelectorAll<HTMLElement>('[contenteditable="false"]')
+    .forEach(neutralizeElement);
+}
+
+/**
  * AriaCleanupPlugin (internal component)
  *
  * Injected into both the root and every nested Lexical composer.
  *
- * Lexical hardcodes several ARIA attributes on its editor element that cause
- * NVDA to treat slide content as an interactive form field rather than readable
- * content. This plugin corrects that by:
+ * Lexical stamps `contenteditable="false"` (plus textbox role / aria-readonly /
+ * aria-autocomplete) onto editor roots and every decorator node. NVDA reports
+ * these as "clickable", so plain slide content reads as interactive.
  *
- * - Removing role="textbox"         (incorrect role for content regions)
- * - Removing contenteditable="false" (presence alone triggers forms mode in NVDA)
- * - Removing aria-readonly           (implies textbox semantics)
- * - Removing aria-autocomplete       (only valid on form inputs)
- * - Setting role="region"            (correct landmark for notable content areas)
- * - Setting aria-label="Slide content" (neutral, accurate label)
+ * The previous implementation used a one-shot `registerRootListener` which:
+ *   1. only saw the editor ROOT — never the decorator descendants (half the
+ *      leaks), and
+ *   2. removed the attribute once, but Lexical re-applies it on every
+ *      reconciliation, so it silently came back.
  *
- * registerRootListener fires when Lexical attaches its editor element to the DOM.
- * The listener is automatically cleaned up when the component unmounts.
+ * This version installs a persistent MutationObserver over the editor subtree
+ * that re-neutralizes root + decorator nodes whenever Lexical re-adds the
+ * attribute or mounts new decorator content (e.g. expanding an accordion/tab).
+ * One install point, applied to root + every nested editor, so it stays
+ * consistent across all directives and both nested-editor forks.
  */
 function AriaCleanupPlugin(): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    return editor.registerRootListener((rootElement) => {
-      if (!rootElement) return;
+    let observer: MutationObserver | null = null;
 
-      // Remove incorrect role if present
-      if (rootElement.getAttribute('role') === 'textbox') {
-        rootElement.removeAttribute('role');
-      }
+    const unregister = editor.registerRootListener(
+      (rootElement: HTMLElement | null) => {
+        // Tear down any observer bound to a previous root element.
+        if (observer) {
+          observer.disconnect();
+          observer = null;
+        }
+        if (!rootElement) return;
 
-      // Remove contenteditable="false" — triggers NVDA forms mode regardless of value
-      if (rootElement.getAttribute('contenteditable') === 'false') {
-        rootElement.removeAttribute('contenteditable');
-      }
+        // Initial pass so content is clean before the first paint / read.
+        neutralizeSubtree(rootElement);
 
-      // Remove aria-readonly — implies textbox semantics even without the role
-      if (rootElement.hasAttribute('aria-readonly')) {
-        rootElement.removeAttribute('aria-readonly');
-      }
+        // Persistent guard: Lexical re-stamps contenteditable on every reconcile
+        // and when new decorator nodes mount. Re-neutralize on any relevant change.
+        observer = new MutationObserver((mutations) => {
+          for (const m of mutations) {
+            if (
+              m.type === 'attributes' &&
+              m.target instanceof HTMLElement
+            ) {
+              neutralizeElement(m.target);
+            } else if (m.type === 'childList') {
+              m.addedNodes.forEach((node) => {
+                if (node instanceof HTMLElement) {
+                  neutralizeSubtree(node);
+                }
+              });
+            }
+          }
+        });
 
-      // Remove aria-autocomplete — only valid on combobox/textbox/list inputs
-      if (rootElement.hasAttribute('aria-autocomplete')) {
-        rootElement.removeAttribute('aria-autocomplete');
+        observer.observe(rootElement, {
+          subtree: true,
+          childList: true,
+          attributes: true,
+          attributeFilter: [
+            'contenteditable',
+            'role',
+            'aria-readonly',
+            'aria-autocomplete',
+            'aria-label',
+          ],
+        });
+      },
+    );
+
+    return () => {
+      if (observer) {
+        observer.disconnect();
+        observer = null;
       }
-      // Remove aria-label if Lexical has set it to "editable markdown" —
-      // wrong context for a content consumer in the player
-      const currentLabel = rootElement.getAttribute('aria-label');
-      if (currentLabel === 'editable markdown') {
-        rootElement.removeAttribute('aria-label');
-      }
-    });
+      unregister();
+    };
   }, [editor]);
 
   return null;


### PR DESCRIPTION
update ariaOverridePlugin to stop NVDA from announcing non-interactive slide content as "clickable."

Use MutationObserver to remove contenteditable="false"  which was cause for many false 'clickable' flags.


**Unfortunately, there are two independent NVDA "clickable" triggers, and this neutralizes only one:** 

After a few hours looking into this , I feel like Michelle's comment of :

"if that isnt possible, we will tell users to tum off the clickable feature from NVDA and it will be a known issue. "

is very much relevant... I really don't see modifying dozens of files to try to get this to work is safe or critical at this point ...especially with the click handlers (which we need) 'trumping' any role=presentation etc type of gating 

@MeganBohlandBylight @micodevstar  ... lemme know if you feel different...  otherwise I'm switching back to my tickets
