### PR TITLE
Update for WCAG compliance that  each page has a title. 

### DIFF
--- a/apps/cc-cmi5-player/src/app/session/AuManager.tsx
+++ b/apps/cc-cmi5-player/src/app/session/AuManager.tsx
@@ -119,6 +119,22 @@ function AuManager() {
   const { isOverridesLoaded, loadOverrides } = useOverrideConfigs();
   const { isContentLoaded, contentErrorMessage, loadContent } = useAuContent();
 
+  /**
+   * 2.4.2 Page Titled (Level A): reflect the AU's own title in the tab title.
+   * Only runs once real content has loaded, so the "Loading..." placeholder
+   * (defaultCourseAuData) never leaks into the title. Falls back to auName
+   * since title is an optional field and may not be authored.
+   * A later org-configured theme.playerTitle (useOverrideConfig) intentionally
+   * overrides this — that's the customer's explicit branding choice.
+   */
+  useEffect(() => {
+    if (!isContentLoaded) return;
+    const displayTitle = auJson?.title || auJson?.auName;
+    if (displayTitle) {
+      document.title = `${displayTitle} | RapidCMI5`;
+    }
+  }, [isContentLoaded, auJson?.title, auJson?.auName]);
+
   //#region Session Methods
 
   const handleSetActivityCache = (


### PR DESCRIPTION
This will make us more compliant for WCAG  2.4.2.

It starts by looking for Au title, and if not found AU name, then defaults to RapidCmi5 player.

https://cybercents.atlassian.net/browse/CCUI-3051