### PR TITLE
Feat/cc UI 3031 add tooltip

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
@@ -52,6 +52,7 @@ function LazyImage({
       id={id}
       className={className ?? undefined}
       alt={alt}
+      aria-label={isLinked ? undefined : `${alt}. Click to view full screen.`}
       src={imgCache.read(url)}
       title={title}
       draggable="false"
@@ -61,7 +62,6 @@ function LazyImage({
       // linked images already navigate via the surrounding <a> on click/enter,
       // so only non-linked images get the full-screen keyboard trigger + warning
       tabIndex={isLinked ? undefined : 0}
-      aria-describedby={isLinked ? undefined : `image-fullscreen-hint-${id}`}
       onKeyDown={
         isLinked
           ? undefined
@@ -74,8 +74,12 @@ function LazyImage({
       }
       // keyboard focus lands on the image itself (it sits under the overlay),
       // so the overlay's tooltip is shown/hidden in sync with focus here too
-      onFocus={isLinked ? undefined : () => onFullscreenHintVisibilityChange(true)}
-      onBlur={isLinked ? undefined : () => onFullscreenHintVisibilityChange(false)}
+      onFocus={
+        isLinked ? undefined : () => onFullscreenHintVisibilityChange(true)
+      }
+      onBlur={
+        isLinked ? undefined : () => onFullscreenHintVisibilityChange(false)
+      }
     />
   );
 }
@@ -188,29 +192,21 @@ export function ImageViewer({
               }}
             />
           ) : (
-            <>
-              <Tooltip title="Click to view full screen" open={showFullscreenHint}>
-                <div
-                  id={`image-labels-${id}`}
-                  ref={labelsRef}
-                  aria-hidden="true"
-                  onMouseEnter={() => setShowFullscreenHint(true)}
-                  onMouseLeave={() => setShowFullscreenHint(false)}
-                  style={{
-                    position: 'absolute',
-                    left: 0,
-                    width: '100%',
-                    height: '100%',
-                  }}
-                />
-              </Tooltip>
-              <span
-                id={`image-fullscreen-hint-${id}`}
-                className={styles['imageFullscreenHint']}
-              >
-                Click to view full screen
-              </span>
-            </>
+            <Tooltip title="Click to view full screen" open={showFullscreenHint}>
+              <div
+                id={`image-labels-${id}`}
+                ref={labelsRef}
+                aria-hidden="true"
+                onMouseEnter={() => setShowFullscreenHint(true)}
+                onMouseLeave={() => setShowFullscreenHint(false)}
+                style={{
+                  position: 'absolute',
+                  left: 0,
+                  width: '100%',
+                  height: '100%',
+                }}
+              />
+            </Tooltip>
           )}
           <LazyImage
             id={id}

--- a/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
@@ -7,6 +7,7 @@ import { imagePlaceholder$ as imagePlaceholderComponent$ } from './index';
 import styles from './styles/image-plugin.module.css';
 import { imagePreviewHandler$, imgCache, parseCssString } from '@rapid-cmi5/ui';
 
+import Tooltip from '@mui/material/Tooltip';
 export interface ImageViewerProps {
   nodeKey: string;
   src: string;
@@ -29,6 +30,8 @@ function LazyImage({
   rest,
   style,
   id,
+  isLinked,
+  onFullscreenHintVisibilityChange,
 }: {
   title: string;
   alt: string;
@@ -39,6 +42,8 @@ function LazyImage({
   rest: (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
   style?: React.CSSProperties;
   id?: string;
+  isLinked: boolean;
+  onFullscreenHintVisibilityChange: (visible: boolean) => void;
 }) {
   const [url] = useState<string>(src);
 
@@ -53,6 +58,24 @@ function LazyImage({
       width={width}
       height={height}
       style={style}
+      // linked images already navigate via the surrounding <a> on click/enter,
+      // so only non-linked images get the full-screen keyboard trigger + warning
+      tabIndex={isLinked ? undefined : 0}
+      aria-describedby={isLinked ? undefined : `image-fullscreen-hint-${id}`}
+      onKeyDown={
+        isLinked
+          ? undefined
+          : (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                document.getElementById(`image-labels-${id}`)?.click();
+              }
+            }
+      }
+      // keyboard focus lands on the image itself (it sits under the overlay),
+      // so the overlay's tooltip is shown/hidden in sync with focus here too
+      onFocus={isLinked ? undefined : () => onFullscreenHintVisibilityChange(true)}
+      onBlur={isLinked ? undefined : () => onFullscreenHintVisibilityChange(false)}
     />
   );
 }
@@ -72,8 +95,22 @@ export function ImageViewer({
     imagePlaceholderComponent$,
     imagePreviewHandler$,
   );
-  const labelsRef = React.useRef<null | HTMLImageElement>(null);
   const [imageSource, setImageSource] = React.useState<string | null>(null);
+  // images inside a link already navigate on click/enter and get their
+  // accessible name from the alt text, so they don't need the full-screen
+  // button/tooltip treatment. The overlay div is only rendered once
+  // imageSource resolves, so a callback ref is used instead of a mount
+  // effect, which would run before the div exists and never fire again.
+  const [isLinked, setIsLinked] = React.useState(false);
+  const labelsRef = React.useCallback((node: HTMLDivElement | null) => {
+    if (node) {
+      setIsLinked(node.closest('a') != null);
+    }
+  }, []);
+  // the tooltip's child (the overlay) only ever gets mouse hover, since
+  // keyboard focus lands on the <img> underneath it - control the tooltip's
+  // open state directly so both trigger it
+  const [showFullscreenHint, setShowFullscreenHint] = React.useState(false);
 
   // determine styles
   let styleAttribute: MdxJsxAttribute | undefined;
@@ -139,16 +176,42 @@ export function ImageViewer({
           className={styles['imageWrapper']}
           data-editor-block-type="image"
         >
-          <div
-            id={`image-labels-${id}`}
-            ref={labelsRef}
-            style={{
-              position: 'absolute',
-              left: 0,
-              width: '100%',
-              height: '100%',
-            }}
-          />
+          {isLinked ? (
+            <div
+              id={`image-labels-${id}`}
+              ref={labelsRef}
+              style={{
+                position: 'absolute',
+                left: 0,
+                width: '100%',
+                height: '100%',
+              }}
+            />
+          ) : (
+            <>
+              <Tooltip title="Click to view full screen" open={showFullscreenHint}>
+                <div
+                  id={`image-labels-${id}`}
+                  ref={labelsRef}
+                  aria-hidden="true"
+                  onMouseEnter={() => setShowFullscreenHint(true)}
+                  onMouseLeave={() => setShowFullscreenHint(false)}
+                  style={{
+                    position: 'absolute',
+                    left: 0,
+                    width: '100%',
+                    height: '100%',
+                  }}
+                />
+              </Tooltip>
+              <span
+                id={`image-fullscreen-hint-${id}`}
+                className={styles['imageFullscreenHint']}
+              >
+                Click to view full screen
+              </span>
+            </>
+          )}
           <LazyImage
             id={id}
             width={width}
@@ -157,6 +220,8 @@ export function ImageViewer({
             src={imageSource}
             title={title ?? ''}
             alt={alt ?? ''}
+            isLinked={isLinked}
+            onFullscreenHintVisibilityChange={setShowFullscreenHint}
             rest={rest}
             style={style}
           />

--- a/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/styles/image-plugin.module.css
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/styles/image-plugin.module.css
@@ -11,6 +11,18 @@
   position: relative;
 }
 
+.imageFullscreenHint {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .focusedImage {
   outline: highlight solid 2px;
 }

--- a/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/styles/image-plugin.module.css
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/styles/image-plugin.module.css
@@ -11,18 +11,6 @@
   position: relative;
 }
 
-.imageFullscreenHint {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .focusedImage {
   outline: highlight solid 2px;
 }


### PR DESCRIPTION
## Summary

Adds an accessible warning before an image expands to full screen, closing a WCAG 3.2.2 (On Input) gap called out in the VPAT: clicking an image previously triggered an unannounced full-screen change with no warning. Sighted users now see a "Click to view full screen" tooltip on both mouse hover and keyboard focus; screen reader users get the same warning folded into the image's accessible name. Images that are already wrapped in a link are left untouched, since clicking those navigates rather than going full screen.

### Changes

- New tooltip (MUI `Tooltip`, with a manually controlled `open` state) shows "Click to view full screen" on mouse hover **and** keyboard focus of the image — previously this kind of affordance would only have covered mouse hover.
- The image itself (not the invisible click-catching overlay div) is the focusable/described element, so it keeps its native `alt` text and `graphic` role — screen readers can still find it via image/graphic navigation (e.g. NVDA's "G" key), and announce "{alt}. Click to view full screen." as one accessible name rather than a name/description pair that depended on the tooltip's open state.
- Detects at render time whether an image sits inside a link (`closest('a')`) and skips the full-screen tooltip/keyboard trigger for those — they navigate instead of going full screen, so the warning would be misleading and would create invalid nested-interactive semantics.


## Test plan
- [ ] Tab to a plain (non-linked) image — confirm the tooltip appears visually on focus, and Enter/Space opens full screen
- [ ] Hover a plain image with a mouse — confirm the tooltip appears, and click opens full screen
- [ ] Tab away / mouse-leave — confirm the tooltip closes
- [ ] With a screen reader (e.g. NVDA), tab to a plain image — confirm it reads as a graphic with alt text followed by "Click to view full screen"
- [ ] Confirm all non-linked images are still found via "jump to next graphic" screen reader navigation
- [ ] Tab to / click an image wrapped in a link — confirm it behaves like a normal link (no tooltip, navigates on click/Enter, no extra nested control)
- [ ] Confirm full-screen click behavior is unaffected for existing courses/images

For CCUI-3031: 
https://cybercents.atlassian.net/browse/CCUI-3031