### PR TITLE
feat: make image marker button toggle content on/off

### DIFF
--- a/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
@@ -30,6 +30,7 @@ import Fade from '@mui/material/Fade';
 
 /** Icons */
 import AddCircleIcon from '@mui/icons-material/AddCircle';
+import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 
 import { ImageLabelDirectiveNode } from './types';
@@ -203,19 +204,27 @@ export const ImageLabelEditor: React.FC<
   };
 
   /**
-   * Open Label Content
+   * Toggle Label Content open/closed
    * @param event
    */
-  const handleOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (imageId) {
-      checkLabelPlacement();
-      setAnchorEl(event?.currentTarget);
-      imageLabelKeys$.value = {
-        ...imageLabelKeys$.value,
-        [imageId]: transientId,
-      };
-      document.removeEventListener('mousedown', handleMouseDown);
-      document.addEventListener('mousedown', handleMouseDown);
+      if (isOpen) {
+        document.removeEventListener('mousedown', handleMouseDown);
+        imageLabelKeys$.value = {
+          ...imageLabelKeys$.value,
+          [imageId]: null,
+        };
+      } else {
+        checkLabelPlacement();
+        setAnchorEl(event?.currentTarget);
+        imageLabelKeys$.value = {
+          ...imageLabelKeys$.value,
+          [imageId]: transientId,
+        };
+        document.removeEventListener('mousedown', handleMouseDown);
+        document.addEventListener('mousedown', handleMouseDown);
+      }
     } else {
       debugLog('no imageId found for label');
     }
@@ -277,11 +286,15 @@ export const ImageLabelEditor: React.FC<
             props={{
               onClick: (event) => {
                 event.stopPropagation();
-                handleOpen(event);
+                handleToggle(event);
               },
             }}
           >
-            <AddCircleIcon color="warning" />
+            {isOpen ? (
+              <RemoveCircleIcon color="warning" />
+            ) : (
+              <AddCircleIcon color="warning" />
+            )}
           </ButtonIcon>
           {!readOnly && !isPlayback && isHovered && (
             <IconButton

--- a/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
@@ -284,6 +284,8 @@ export const ImageLabelEditor: React.FC<
           <ButtonIcon
             name="Image Marker"
             props={{
+              'aria-expanded': isOpen,
+              'aria-label': isOpen ? 'Hide label content' : 'Show label content',
               onClick: (event) => {
                 event.stopPropagation();
                 handleToggle(event);


### PR DESCRIPTION
## Summary

Adds toggle behavior to the image marker button used on images in both the design-tool editor and the live player. When a marker's content is hidden, the button now shows a + icon and clicking it reveals the content; when the content is visible, the button shows a - icon and clicking it hides the content — no more needing to click outside the label to close it, which was especially awkward for keyboard-only users.

### Changes

- Marker click handler (`handleOpen` → `handleToggle`) now branches on the label's open state: closing clears the open-label signal and removes the outside-click listener, instead of the handler only ever being able to open.
- Marker icon swaps between `AddCircleIcon` (closed) and `RemoveCircleIcon` (open) so the button visually reflects state.
- `ImageLabelEditor.tsx` is shared by both the design-tool editor and the actual player, so this one change fixes the behavior in both places.

### Ticket CCUI-2827
https://cybercents.atlassian.net/browse/CCUI-2827

## Test plan
- [ ] Click a marker with hidden content — content appears, icon changes to -
- [ ] Click the same marker again — content disappears, icon reverts to +
- [ ] Tab to a marker via keyboard and activate with Enter/Space — same toggle behavior, no mouse required
- [ ] Click outside an open marker's content — content still closes (existing behavior preserved)
- [ ] Confirm behavior is consistent in both the design-tool editor and the actual player
