### PR TITLE
Fix/cc UI 2982 video form changing fix

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
@@ -49,6 +49,27 @@ const VIDEO_DIR = './Assets/Videos/';
 
 const NEGATIVE_VALUE_ERROR_TEXT = 'Negative values are not allowed';
 
+// The width/height fields sit in a center-aligned Grid row, so anything that
+// changes their height shifts the neighbouring field. Take the helper text out
+// of flow and pin it below the input: the error message can then appear (and
+// wrap) without altering the field's box. `align-items: center` fixes the info
+// `?` button, which otherwise stretches to the row height instead of centering
+// on the input.
+const dimensionFieldProps = {
+  sxProps: {
+    position: 'relative',
+    '& .MuiFormHelperText-root': {
+      position: 'absolute',
+      top: '100%',
+      left: 0,
+      right: 0,
+      marginTop: 0,
+      marginLeft: '14px',
+    },
+  },
+  containerSxProps: { alignItems: 'center' },
+} as const;
+
 // shared onChange handler for the width/height fields: rejects negative
 // values (surfacing the error state) and otherwise applies the new value
 const createNonNegativeChangeHandler =
@@ -375,6 +396,7 @@ export const VideoDialog: React.FC = () => {
                 helperText={widthError ? NEGATIVE_VALUE_ERROR_TEXT : undefined}
                 onChange={createNonNegativeChangeHandler(setWidth, setWidthError)}
                 infoText={'Optional video width in pixels'}
+                {...dimensionFieldProps}
               />
             </Grid>
             <Grid size={4.5}>
@@ -389,6 +411,7 @@ export const VideoDialog: React.FC = () => {
                 helperText={heightError ? NEGATIVE_VALUE_ERROR_TEXT : undefined}
                 onChange={createNonNegativeChangeHandler(setHeight, setHeightError)}
                 infoText={'Optional video height in pixels'}
+                {...dimensionFieldProps}
               />
             </Grid>
 

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
@@ -83,8 +83,16 @@ export const VideoDialog: React.FC = () => {
       setTitle(state.initialValues.title ? state.initialValues.title : '');
 
       setVideoStyle('');
-      setWidth(state.initialValues.width?.toString() ?? '');
-      setHeight(state.initialValues.height?.toString() ?? '');
+      setWidth(
+        state.initialValues.width && state.initialValues.width > 0
+          ? state.initialValues.width.toString()
+          : '',
+      );
+      setHeight(
+        state.initialValues.height && state.initialValues.height > 0
+          ? state.initialValues.height.toString()
+          : '',
+      );
       setAutoplay(state.initialValues.autoplay ?? false);
       setCaptionSrc(state.initialValues.captionSrc ?? '');
       setDialogOpenCount((c) => c + 1);
@@ -227,6 +235,7 @@ export const VideoDialog: React.FC = () => {
         buttons={['Cancel', state.type === 'editing' ? 'apply' : 'insert']}
         dialogProps={{
           open: true,
+          fullWidth: true,
         }}
         handleAction={(index: number) => {
           if (index === 0) {
@@ -340,8 +349,13 @@ export const VideoDialog: React.FC = () => {
                 label="Width (px)"
                 name="video-width"
                 type="number"
+                inputProps={{ min: 0 }}
                 value={width}
-                onChange={(textValue: string) => setWidth(textValue)}
+                onChange={(textValue: string) => {
+                  if (textValue === '' || Number(textValue) >= 0) {
+                    setWidth(textValue);
+                  }
+                }}
                 infoText={'Optional video width in pixels'}
               />
             </Grid>
@@ -351,8 +365,13 @@ export const VideoDialog: React.FC = () => {
                 label="Height (px)"
                 name="video-height"
                 type="number"
+                inputProps={{ min: 0 }}
                 value={height}
-                onChange={(textValue: string) => setHeight(textValue)}
+                onChange={(textValue: string) => {
+                  if (textValue === '' || Number(textValue) >= 0) {
+                    setHeight(textValue);
+                  }
+                }}
                 infoText={'Optional video height in pixels'}
               />
             </Grid>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
@@ -60,6 +60,8 @@ export const VideoDialog: React.FC = () => {
   const [fileOptions, setFileOptions] = useState<string[]>([]);
   const [width, setWidth] = useState<string>('');
   const [height, setHeight] = useState<string>('');
+  const [widthError, setWidthError] = useState<boolean>(false);
+  const [heightError, setHeightError] = useState<boolean>(false);
   const [autoplay, setAutoplay] = useState<boolean>(false);
   const { getAllAssets } = useLessonAssets();
   const [captionSrc, setCaptionSrc] = useState<string>('');
@@ -78,6 +80,9 @@ export const VideoDialog: React.FC = () => {
   // set the initial values based on if the user is inserting a new video or
   // editing an existing video
   useEffect(() => {
+    setWidthError(false);
+    setHeightError(false);
+
     if (state.type === 'editing') {
       setSrc(state.initialValues.src ? state.initialValues.src : '');
       setTitle(state.initialValues.title ? state.initialValues.title : '');
@@ -351,9 +356,14 @@ export const VideoDialog: React.FC = () => {
                 type="number"
                 inputProps={{ min: 0 }}
                 value={width}
+                error={widthError}
+                helperText={widthError ? 'Negative values are not allowed' : undefined}
                 onChange={(textValue: string) => {
                   if (textValue === '' || Number(textValue) >= 0) {
                     setWidth(textValue);
+                    setWidthError(false);
+                  } else {
+                    setWidthError(true);
                   }
                 }}
                 infoText={'Optional video width in pixels'}
@@ -367,9 +377,14 @@ export const VideoDialog: React.FC = () => {
                 type="number"
                 inputProps={{ min: 0 }}
                 value={height}
+                error={heightError}
+                helperText={heightError ? 'Negative values are not allowed' : undefined}
                 onChange={(textValue: string) => {
                   if (textValue === '' || Number(textValue) >= 0) {
                     setHeight(textValue);
+                    setHeightError(false);
+                  } else {
+                    setHeightError(true);
                   }
                 }}
                 infoText={'Optional video height in pixels'}

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
@@ -47,6 +47,21 @@ const VisuallyHiddenInput = styled('input')({
 
 const VIDEO_DIR = './Assets/Videos/';
 
+const NEGATIVE_VALUE_ERROR_TEXT = 'Negative values are not allowed';
+
+// shared onChange handler for the width/height fields: rejects negative
+// values (surfacing the error state) and otherwise applies the new value
+const createNonNegativeChangeHandler =
+  (setValue: (value: string) => void, setError: (hasError: boolean) => void) =>
+  (textValue: string) => {
+    if (textValue === '' || Number(textValue) >= 0) {
+      setValue(textValue);
+      setError(false);
+    } else {
+      setError(true);
+    }
+  };
+
 /**
  * A custom Video Dialog for video settings.
  * @constructor
@@ -357,15 +372,8 @@ export const VideoDialog: React.FC = () => {
                 inputProps={{ min: 0 }}
                 value={width}
                 error={widthError}
-                helperText={widthError ? 'Negative values are not allowed' : undefined}
-                onChange={(textValue: string) => {
-                  if (textValue === '' || Number(textValue) >= 0) {
-                    setWidth(textValue);
-                    setWidthError(false);
-                  } else {
-                    setWidthError(true);
-                  }
-                }}
+                helperText={widthError ? NEGATIVE_VALUE_ERROR_TEXT : undefined}
+                onChange={createNonNegativeChangeHandler(setWidth, setWidthError)}
                 infoText={'Optional video width in pixels'}
               />
             </Grid>
@@ -378,15 +386,8 @@ export const VideoDialog: React.FC = () => {
                 inputProps={{ min: 0 }}
                 value={height}
                 error={heightError}
-                helperText={heightError ? 'Negative values are not allowed' : undefined}
-                onChange={(textValue: string) => {
-                  if (textValue === '' || Number(textValue) >= 0) {
-                    setHeight(textValue);
-                    setHeightError(false);
-                  } else {
-                    setHeightError(true);
-                  }
-                }}
+                helperText={heightError ? NEGATIVE_VALUE_ERROR_TEXT : undefined}
+                onChange={createNonNegativeChangeHandler(setHeight, setHeightError)}
                 infoText={'Optional video height in pixels'}
               />
             </Grid>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
@@ -47,14 +47,14 @@ const VisuallyHiddenInput = styled('input')({
 
 const VIDEO_DIR = './Assets/Videos/';
 
-const NEGATIVE_VALUE_ERROR_TEXT = 'Negative values are not allowed';
+const INVALID_VALUE_ERROR_TEXT = 'Value must be greater than 0';
 
-// shared onChange handler for the width/height fields: rejects negative
-// values (surfacing the error state) and otherwise applies the new value
-const createNonNegativeChangeHandler =
+// shared onChange handler for the width/height fields: rejects zero and
+// negative values (surfacing the error state) and otherwise applies the new value
+const createPositiveValueChangeHandler =
   (setValue: (value: string) => void, setError: (hasError: boolean) => void) =>
   (textValue: string) => {
-    if (textValue === '' || Number(textValue) >= 0) {
+    if (textValue === '' || Number(textValue) > 0) {
       setValue(textValue);
       setError(false);
     } else {
@@ -369,11 +369,11 @@ export const VideoDialog: React.FC = () => {
                 label="Width (px)"
                 name="video-width"
                 type="number"
-                inputProps={{ min: 0 }}
+                inputProps={{ min: 1 }}
                 value={width}
                 error={widthError}
-                helperText={widthError ? NEGATIVE_VALUE_ERROR_TEXT : undefined}
-                onChange={createNonNegativeChangeHandler(setWidth, setWidthError)}
+                helperText={widthError ? INVALID_VALUE_ERROR_TEXT : undefined}
+                onChange={createPositiveValueChangeHandler(setWidth, setWidthError)}
                 infoText={'Optional video width in pixels'}
               />
             </Grid>
@@ -383,11 +383,11 @@ export const VideoDialog: React.FC = () => {
                 label="Height (px)"
                 name="video-height"
                 type="number"
-                inputProps={{ min: 0 }}
+                inputProps={{ min: 1 }}
                 value={height}
                 error={heightError}
-                helperText={heightError ? NEGATIVE_VALUE_ERROR_TEXT : undefined}
-                onChange={createNonNegativeChangeHandler(setHeight, setHeightError)}
+                helperText={heightError ? INVALID_VALUE_ERROR_TEXT : undefined}
+                onChange={createPositiveValueChangeHandler(setHeight, setHeightError)}
                 infoText={'Optional video height in pixels'}
               />
             </Grid>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
@@ -49,27 +49,6 @@ const VIDEO_DIR = './Assets/Videos/';
 
 const NEGATIVE_VALUE_ERROR_TEXT = 'Negative values are not allowed';
 
-// The width/height fields sit in a center-aligned Grid row, so anything that
-// changes their height shifts the neighbouring field. Take the helper text out
-// of flow and pin it below the input: the error message can then appear (and
-// wrap) without altering the field's box. `align-items: center` fixes the info
-// `?` button, which otherwise stretches to the row height instead of centering
-// on the input.
-const dimensionFieldProps = {
-  sxProps: {
-    position: 'relative',
-    '& .MuiFormHelperText-root': {
-      position: 'absolute',
-      top: '100%',
-      left: 0,
-      right: 0,
-      marginTop: 0,
-      marginLeft: '14px',
-    },
-  },
-  containerSxProps: { alignItems: 'center' },
-} as const;
-
 // shared onChange handler for the width/height fields: rejects negative
 // values (surfacing the error state) and otherwise applies the new value
 const createNonNegativeChangeHandler =
@@ -396,7 +375,6 @@ export const VideoDialog: React.FC = () => {
                 helperText={widthError ? NEGATIVE_VALUE_ERROR_TEXT : undefined}
                 onChange={createNonNegativeChangeHandler(setWidth, setWidthError)}
                 infoText={'Optional video width in pixels'}
-                {...dimensionFieldProps}
               />
             </Grid>
             <Grid size={4.5}>
@@ -411,7 +389,6 @@ export const VideoDialog: React.FC = () => {
                 helperText={heightError ? NEGATIVE_VALUE_ERROR_TEXT : undefined}
                 onChange={createNonNegativeChangeHandler(setHeight, setHeightError)}
                 infoText={'Optional video height in pixels'}
-                {...dimensionFieldProps}
               />
             </Grid>
 

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
@@ -131,13 +131,35 @@ export const VideoDialog: React.FC = () => {
     closeVideoDialog();
   };
 
-  // silently ignores zero and negative width/height entries (the field
-  // keeps its last valid value) instead of storing the bad value
-  const ensurePositiveValueChangeHandler =
+  // while typing, allow decimals through (rounded on blur below) but
+  // silently ignore negative/non-numeric entries - the field keeps its
+  // last valid value instead of storing a bad one
+  const ensureNonNegativeValueChangeHandler =
     (setValue: (value: string) => void) => (textValue: string) => {
-      if (textValue === '' || Number(textValue) > 0) {
+      if (textValue === '' || Number(textValue) >= 0) {
         setValue(textValue);
       }
+    };
+
+  // rounds to the nearest whole number (0.5 -> 1, 6.8 -> 7) since
+  // width/height are pixel values; returns undefined if it rounds to <= 0
+  const roundToPositiveInteger = (value: string): number | undefined => {
+    if (value === '') {
+      return undefined;
+    }
+    const rounded = Math.round(Number(value));
+    return rounded > 0 ? rounded : undefined;
+  };
+
+  // on blur, snap the field itself to the rounded value so the user sees
+  // what will actually be submitted
+  const roundToPositiveIntegerOnBlur =
+    (currentValue: string, setValue: (value: string) => void) => () => {
+      if (currentValue === '') {
+        return;
+      }
+      const rounded = roundToPositiveInteger(currentValue);
+      setValue(rounded !== undefined ? String(rounded) : '');
     };
 
   // the user is submitting the video, so insert it
@@ -158,8 +180,8 @@ export const VideoDialog: React.FC = () => {
       src: src,
       title: title,
       rest: restParams,
-      width: width ? parseInt(width, 10) : undefined,
-      height: height ? parseInt(height, 10) : undefined,
+      width: roundToPositiveInteger(width),
+      height: roundToPositiveInteger(height),
       autoplay: autoplay,
       captionSrc: captionSrc || undefined,
       captionFile: selectedCaptionFiles,
@@ -359,8 +381,10 @@ export const VideoDialog: React.FC = () => {
                 name="video-width"
                 type="number"
                 inputProps={{ min: 1 }}
+                forceNumberAsInteger={false}
                 value={width}
-                onChange={ensurePositiveValueChangeHandler(setWidth)}
+                onChange={ensureNonNegativeValueChangeHandler(setWidth)}
+                onBlur={roundToPositiveIntegerOnBlur(width, setWidth)}
                 infoText={'Optional video width in pixels'}
               />
             </Grid>
@@ -371,8 +395,10 @@ export const VideoDialog: React.FC = () => {
                 name="video-height"
                 type="number"
                 inputProps={{ min: 1 }}
+                forceNumberAsInteger={false}
                 value={height}
-                onChange={ensurePositiveValueChangeHandler(setHeight)}
+                onChange={ensureNonNegativeValueChangeHandler(setHeight)}
+                onBlur={roundToPositiveIntegerOnBlur(height, setHeight)}
                 infoText={'Optional video height in pixels'}
               />
             </Grid>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/VideoDialog.tsx
@@ -47,21 +47,6 @@ const VisuallyHiddenInput = styled('input')({
 
 const VIDEO_DIR = './Assets/Videos/';
 
-const INVALID_VALUE_ERROR_TEXT = 'Value must be greater than 0';
-
-// shared onChange handler for the width/height fields: rejects zero and
-// negative values (surfacing the error state) and otherwise applies the new value
-const createPositiveValueChangeHandler =
-  (setValue: (value: string) => void, setError: (hasError: boolean) => void) =>
-  (textValue: string) => {
-    if (textValue === '' || Number(textValue) > 0) {
-      setValue(textValue);
-      setError(false);
-    } else {
-      setError(true);
-    }
-  };
-
 /**
  * A custom Video Dialog for video settings.
  * @constructor
@@ -75,8 +60,6 @@ export const VideoDialog: React.FC = () => {
   const [fileOptions, setFileOptions] = useState<string[]>([]);
   const [width, setWidth] = useState<string>('');
   const [height, setHeight] = useState<string>('');
-  const [widthError, setWidthError] = useState<boolean>(false);
-  const [heightError, setHeightError] = useState<boolean>(false);
   const [autoplay, setAutoplay] = useState<boolean>(false);
   const { getAllAssets } = useLessonAssets();
   const [captionSrc, setCaptionSrc] = useState<string>('');
@@ -95,9 +78,6 @@ export const VideoDialog: React.FC = () => {
   // set the initial values based on if the user is inserting a new video or
   // editing an existing video
   useEffect(() => {
-    setWidthError(false);
-    setHeightError(false);
-
     if (state.type === 'editing') {
       setSrc(state.initialValues.src ? state.initialValues.src : '');
       setTitle(state.initialValues.title ? state.initialValues.title : '');
@@ -150,6 +130,15 @@ export const VideoDialog: React.FC = () => {
   const handleCancel = () => {
     closeVideoDialog();
   };
+
+  // silently ignores zero and negative width/height entries (the field
+  // keeps its last valid value) instead of storing the bad value
+  const ensurePositiveValueChangeHandler =
+    (setValue: (value: string) => void) => (textValue: string) => {
+      if (textValue === '' || Number(textValue) > 0) {
+        setValue(textValue);
+      }
+    };
 
   // the user is submitting the video, so insert it
   const handleSubmit = () => {
@@ -371,9 +360,7 @@ export const VideoDialog: React.FC = () => {
                 type="number"
                 inputProps={{ min: 1 }}
                 value={width}
-                error={widthError}
-                helperText={widthError ? INVALID_VALUE_ERROR_TEXT : undefined}
-                onChange={createPositiveValueChangeHandler(setWidth, setWidthError)}
+                onChange={ensurePositiveValueChangeHandler(setWidth)}
                 infoText={'Optional video width in pixels'}
               />
             </Grid>
@@ -385,9 +372,7 @@ export const VideoDialog: React.FC = () => {
                 type="number"
                 inputProps={{ min: 1 }}
                 value={height}
-                error={heightError}
-                helperText={heightError ? INVALID_VALUE_ERROR_TEXT : undefined}
-                onChange={createPositiveValueChangeHandler(setHeight, setHeightError)}
+                onChange={ensurePositiveValueChangeHandler(setHeight)}
                 infoText={'Optional video height in pixels'}
               />
             </Grid>

--- a/packages/ui/src/lib/inputs/textfields/textfields.tsx
+++ b/packages/ui/src/lib/inputs/textfields/textfields.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 /* MUI */
 import TextField, { StandardTextFieldProps } from '@mui/material/TextField';
-import { InputAdornment } from '@mui/material';
+import { Box, InputAdornment } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { ButtonIcon, ButtonInfoField } from '../../utility/buttons';
 
@@ -20,6 +20,7 @@ const leadingZeroRegex = /^([0][0-9]+)$|^([-][0][0-9]+)$/; // don't allow -0n or
  * @property {boolean} [forceNumberAsInteger=true] Force textField with type "number" entry to be an integer (no decimal)
  * @property {*} [sxProps] sx props passed to MUI Textfield
  * @property {*} [sxInputProps] sx props passed to internal input field
+ * @property {*} [containerSxProps] sx props passed to the row wrapping the field and its info button
  * @property {(val?: any) => void} [onChange] Callback for text change
  * @property {(val?: any) => void} [onEnter] Callback for enter pressed
  */
@@ -35,6 +36,7 @@ interface BrandedTextfieldProps extends StandardTextFieldProps {
   forceNumberAsInteger?: boolean;
   sxProps?: any;
   sxInputProps?: any;
+  containerSxProps?: any;
   onChange?: (val?: any) => void;
   onEnter?: (val?: any) => void;
 }
@@ -53,6 +55,7 @@ export function TextFieldMainUi(props: BrandedTextfieldProps) {
     forceNumberAsInteger = true,
     sxProps,
     sxInputProps,
+    containerSxProps,
     onChange,
     onEnter,
     ...textFieldProps
@@ -91,7 +94,7 @@ export function TextFieldMainUi(props: BrandedTextfieldProps) {
   ) : null;
 
   return (
-    <div className="content-row">
+    <Box className="content-row" sx={containerSxProps}>
       <TextField
         autoComplete="off"
         inputRef={inputRef}
@@ -168,6 +171,6 @@ export function TextFieldMainUi(props: BrandedTextfieldProps) {
         }}
       />
       {infoText && <ButtonInfoField message={infoText} />}
-    </div>
+    </Box>
   );
 }

--- a/packages/ui/src/lib/inputs/textfields/textfields.tsx
+++ b/packages/ui/src/lib/inputs/textfields/textfields.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 /* MUI */
 import TextField, { StandardTextFieldProps } from '@mui/material/TextField';
-import { Box, InputAdornment } from '@mui/material';
+import { InputAdornment } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { ButtonIcon, ButtonInfoField } from '../../utility/buttons';
 
@@ -20,7 +20,6 @@ const leadingZeroRegex = /^([0][0-9]+)$|^([-][0][0-9]+)$/; // don't allow -0n or
  * @property {boolean} [forceNumberAsInteger=true] Force textField with type "number" entry to be an integer (no decimal)
  * @property {*} [sxProps] sx props passed to MUI Textfield
  * @property {*} [sxInputProps] sx props passed to internal input field
- * @property {*} [containerSxProps] sx props passed to the row wrapping the field and its info button
  * @property {(val?: any) => void} [onChange] Callback for text change
  * @property {(val?: any) => void} [onEnter] Callback for enter pressed
  */
@@ -36,7 +35,6 @@ interface BrandedTextfieldProps extends StandardTextFieldProps {
   forceNumberAsInteger?: boolean;
   sxProps?: any;
   sxInputProps?: any;
-  containerSxProps?: any;
   onChange?: (val?: any) => void;
   onEnter?: (val?: any) => void;
 }
@@ -55,7 +53,6 @@ export function TextFieldMainUi(props: BrandedTextfieldProps) {
     forceNumberAsInteger = true,
     sxProps,
     sxInputProps,
-    containerSxProps,
     onChange,
     onEnter,
     ...textFieldProps
@@ -94,7 +91,7 @@ export function TextFieldMainUi(props: BrandedTextfieldProps) {
   ) : null;
 
   return (
-    <Box className="content-row" sx={containerSxProps}>
+    <div className="content-row">
       <TextField
         autoComplete="off"
         inputRef={inputRef}
@@ -171,6 +168,6 @@ export function TextFieldMainUi(props: BrandedTextfieldProps) {
         }}
       />
       {infoText && <ButtonInfoField message={infoText} />}
-    </Box>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

The "Edit Video" / "Insert Video" dialog no longer resizes while you type in the Width or Height fields, and it now blocks negative dimensions instead of silently accepting them. 

### Changes

- Reject zero/negative width and height entries at the input level, and on the initial-value hydration path when editing an existing video (`state.initialValues.width/height`), instead of allowing them through.
- Allow decimal entry in the width/height fields (`forceNumberAsInteger={false}`) and round to the nearest whole number on blur and on submit (0.5 → 1, 6.8 → 7), rather than truncating with `parseInt` (which silently turned 0.5/6.8 into 0/6).
- Removed the earlier visible error/helper-text UI ("Value must be greater than 0") in favor of silently ignoring invalid input and keeping the field's last valid value — avoids the error getting stuck showing on an already-blank field.
- Set `fullWidth: true` on the dialog so it no longer resizes/reflows as validation state changes.


### Ticket number 2982
https://cybercents.atlassian.net/browse/CCUI-2982?actionerId=5d88d7d68189fd0dc3e9ee95&sourceType=assign

## Test plan
- [ ] Open "Edit Video" on an existing video and confirm the dialog stays a fixed size while typing digits into Width and Height.
- [ ] Type `-5` (or paste it) into Width/Height and confirm the field does not allow it.
- [ ] Type `0.5` (or paste it) into Width/Height and confirm the field updates to '1'.
- [ ] Type or paste '6.8' and confirm field goes to '7.'
- [ ] Enter a valid width/height, confirm the error clears, save, and reopen the dialog to confirm the value persisted correctly.
- [ ] Insert a brand-new video (no prior width/height) and confirm the fields still behave normally (blank by default, accept positive values, save/load correctly).
