### PR TITLE
feat(cmi5-editor): prevent create/rename duplicate lessons (CCUI-2775)

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/CourseBuilderApiTypes.ts
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/CourseBuilderApiTypes.ts
@@ -3,6 +3,8 @@ export type CreateLessonType = {
   coursePath: string;
   auName: string;
   blockName: string;
+  /** Existing AU names in the target block, used to enforce name uniqueness */
+  existingAuNames?: string[];
 };
 
 export type CreateCloneType = {

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/CreateLessonForm.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/courses/CreateLessonForm.tsx
@@ -15,7 +15,7 @@ import Grid from '@mui/material/Grid2';
 import { UseFormReturn } from 'react-hook-form';
 
 import { CreateLessonType } from '../../CourseBuilderApiTypes';
-import { NAME_GROUP } from '@rapid-cmi5/ui';
+import { UNIQUE_NAME_GROUP } from '@rapid-cmi5/ui';
 import { createNewLessonModalId } from '../../../rapidcmi5_mdx/modals/constants';
 
 export function CreateLessonForm({
@@ -36,8 +36,12 @@ export function CreateLessonForm({
   onCreateLesson: (req: CreateLessonType) => void;
 }) {
   const validationSchema = yup.object().shape({
-    auName: NAME_GROUP,
+    auName: UNIQUE_NAME_GROUP(
+      'existingAuNames',
+      'A lesson with this name already exists',
+    ),
     // courseName: auto-filled in - readOnly
+    // existingAuNames: sibling list read by UNIQUE_NAME_GROUP - not validated
   });
 
   const onCancel = () => {

--- a/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/git/SelectGitDialogs.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/course-builder/modals/git/SelectGitDialogs.tsx
@@ -64,7 +64,7 @@ export function SelectGitDialogs() {
     (state: RootState) => state.repoManager,
   );
 
-  const { handleCreateLesson } = useCourseData();
+  const { handleCreateLesson, courseData } = useCourseData();
   const {
     currentCourse,
     availableCourses,
@@ -441,6 +441,12 @@ export function SelectGitDialogs() {
             courseName: modalObj.meta.courseName,
             blockName: modalObj.meta.blockName,
             coursePath: modalObj.meta.coursePath,
+            existingAuNames:
+              courseData?.blocks
+                ?.find(
+                  (block) => block.blockName === modalObj.meta.blockName,
+                )
+                ?.aus?.map((au) => au.auName) ?? [],
           }}
           modalObj={modalObj}
           handleCloseModal={handleCloseModal}

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/drawers/components/LessonTree.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/drawers/components/LessonTree.tsx
@@ -110,6 +110,25 @@ function LessonTree({
     if (element.type === LessonTreeNodeType.Slide) {
       changeSlideName(newName, element);
     } else if (element.type === LessonTreeNodeType.Lesson) {
+      // Prevent renaming a lesson to a name already used by another lesson in
+      // the same block (case-insensitive). Duplicate AU names break navigation
+      // because lessons are resolved by name. See changeLesson() in useCourseData.
+      const blockIndex =
+        typeof element.block === 'number' ? element.block : currentBlockIndex;
+      const lessonIndex = element.id as number;
+      const normalized = newName.trim().toLowerCase();
+      const isDuplicate = courseData?.blocks?.[blockIndex]?.aus?.some(
+        (au, index) =>
+          index !== lessonIndex &&
+          au.auName?.trim().toLowerCase() === normalized,
+      );
+      if (isDuplicate) {
+        displayToaster({
+          message: 'A lesson with this name already exists',
+          severity: 'error',
+        });
+        return;
+      }
       changeLessonName(newName, element);
     }
   };

--- a/packages/ui/src/lib/validation/validation.spec.ts
+++ b/packages/ui/src/lib/validation/validation.spec.ts
@@ -7,6 +7,7 @@ import {
   DNS_RECORD_NAME_GROUP,
   DNS_RECORD_DATA_GROUP,
   ENUM_GROUP,
+  UNIQUE_NAME_GROUP,
   UUID_BASE,
   UUID_GROUP_OPTIONS,
   UUID_ONLY_ONE_FROM_GROUP,
@@ -14,6 +15,52 @@ import {
   getOptIntegerWithUnitsValidation,
   RESOURCE_QUANTITY_WITH_MINIMUM_GROUP,
 } from '@rapid-cmi5/ui';
+
+describe('UNIQUE_NAME_GROUP validates', () => {
+  const schema = yup.object().shape({
+    field: UNIQUE_NAME_GROUP('existingNames'),
+  });
+
+  it('should pass for a name not in the existing list', async () => {
+    const result = await schema.isValid({
+      field: 'Lesson2',
+      existingNames: ['Lesson1'],
+    });
+    expect(result).toEqual(true);
+  });
+  it('should pass when there are no existing names', async () => {
+    const result = await schema.isValid({ field: 'Lesson1' });
+    expect(result).toEqual(true);
+  });
+  it('should fail for an exact duplicate name', async () => {
+    const result = await schema.isValid({
+      field: 'Lesson1',
+      existingNames: ['Lesson1'],
+    });
+    expect(result).toEqual(false);
+  });
+  it('should fail for a case-insensitive duplicate name', async () => {
+    const result = await schema.isValid({
+      field: 'lesson1',
+      existingNames: ['Lesson1'],
+    });
+    expect(result).toEqual(false);
+  });
+  it('should fail for a duplicate name differing only by surrounding whitespace', async () => {
+    const result = await schema.isValid({
+      field: '  Lesson1  ',
+      existingNames: ['Lesson1'],
+    });
+    expect(result).toEqual(false);
+  });
+  it('should still enforce the required rule from NAME_GROUP', async () => {
+    const result = await schema.isValid({
+      field: '',
+      existingNames: ['Lesson1'],
+    });
+    expect(result).toEqual(false);
+  });
+});
 
 describe('CERTIFICATE_SUBJECT_GROUP validates', () => {
   const schema = yup.object().shape({

--- a/packages/ui/src/lib/validation/validation.ts
+++ b/packages/ui/src/lib/validation/validation.ts
@@ -142,6 +142,33 @@ export const NAME_GROUP = yup
   .trim(NAME_BASE.spacesError)
   .strict(true);
 
+/** @constant
+ * Required Name Field that must be unique (case-insensitive) among a sibling
+ * list of existing names.
+ *
+ * The list of names to compare against is read from the sibling form field
+ * named by `existingNamesField` (default `existingNames`). This mirrors the
+ * `CONTAINER_TAG_GROUP` pattern where the comparison list is threaded through
+ * the form data rather than baked into the schema.
+ *
+ * @param {string} [existingNamesField='existingNames'] Sibling field holding string[] of taken names
+ * @param {string} [uniquenessError] Error message shown on a duplicate
+ */
+export const UNIQUE_NAME_GROUP = (
+  existingNamesField = 'existingNames',
+  uniquenessError = 'Name must be unique',
+) =>
+  NAME_GROUP.test('is-unique-name', uniquenessError, function (value) {
+    const existingNames: string[] = this.parent[existingNamesField] ?? [];
+    if (!value || existingNames.length === 0) {
+      return true;
+    }
+    const normalized = value.trim().toLowerCase();
+    return !existingNames.some(
+      (name) => name?.trim().toLowerCase() === normalized,
+    );
+  });
+
 export const LONG_NAME_GROUP_OPT = yup
   .string()
   .nullable()


### PR DESCRIPTION
## Summary
User could create a new lesson with a duplicate name or rename to same name. Prevent those with info to user.


## Test plan
- [ ] attempt to create new lesson with same name as existing. should not be able to with warning
- [ ] attempt to rename lesson to same name as existing. should not be able to with warning