### PR TITLE
Fix/cc UI 3065 stepper accessibility issues

### DIFF
--- a/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepContentEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepContentEditor.tsx
@@ -97,7 +97,7 @@ export const StepContentEditor: React.FC<
       }}
       role="tabpanel"
       id={`tabpanel-${tabIndex}`}
-      aria-labelledby={`tab-${tabIndex}`}
+      aria-labelledby={`step-${tabIndex}`}
     >
       {alignmentStyles}
 

--- a/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
@@ -592,6 +592,7 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
                       name="reset-step"
                       tooltip={`Step ${index + 1}`}
                       props={{
+                        'aria-label': `Step ${index + 1}`,
                         onClick: () => handleStepChange(index),
                       }}
                       sxProps={{ minWidth: '32px' }}

--- a/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
@@ -124,7 +124,7 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
 
   const a11yStepProps = (index: number) => ({
     id: `step-${index}`,
-    'aria-controls': `step-panel-${index}`,
+    'aria-controls': `tabpanel-${index}`,
   });
 
   /**
@@ -592,6 +592,8 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
                       name="reset-step"
                       tooltip={`Step ${index + 1}`}
                       props={{
+                        id: `step-${index}`,
+                        'aria-controls': `tabpanel-${index}`,
                         'aria-label': `Step ${index + 1}`,
                         onClick: () => handleStepChange(index),
                         'aria-current': index === step ? 'step' : undefined,

--- a/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
@@ -594,6 +594,7 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
                       props={{
                         'aria-label': `Step ${index + 1}`,
                         onClick: () => handleStepChange(index),
+                        'aria-current': index === step ? 'step' : undefined,
                       }}
                       sxProps={{ minWidth: '32px' }}
                     >

--- a/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
@@ -10,7 +10,14 @@ import * as Mdast from 'mdast';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import type { BlockContent, DefinitionContent } from 'mdast';
 import { ContainerDirective } from 'mdast-util-directive';
-import { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  CSSProperties,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   Box,
@@ -88,7 +95,6 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
   const [step, setStep] = useState(0);
   const [stepCount, setStepCount] = useState(0);
   const [sxProps, setSxProps] = useState<SxProps>({});
-  const [title, setTitle] = useState('');
 
   const [isPlayback, readOnly] = useCellValues(editorInPlayback$, readOnly$);
 
@@ -122,7 +128,24 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
 
   const skipNextCloseRebuildRef = useRef(false);
   const headingRef = useRef<HTMLElement>(null);
-  const isFirstTitleRenderRef = useRef(true);
+  const isFirstStepRenderRef = useRef(true);
+
+  /**
+   * Title for the current step, derived directly from the mdast so it
+   * updates in the same render as `step` (no state round-trip that could
+   * lag behind or fail to change when titles repeat).
+   */
+  const title = useMemo(() => {
+    if (
+      Object.prototype.hasOwnProperty.call(
+        mdastNode.children[step].attributes,
+        'title',
+      )
+    ) {
+      return mdastNode.children[step].attributes['title'] || '';
+    }
+    return '';
+  }, [step, mdastNode]);
 
   const a11yStepProps = (index: number) => ({
     id: `step-${index}`,
@@ -353,7 +376,7 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
   }, [isConfiguring]);
 
   /**
-   * UE Sets title for current step
+   * UE Applies block style overrides
    */
   useEffect(() => {
     if (mdastNode.attributes.style) {
@@ -364,36 +387,23 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
         // no styles applied
       }
     }
-
-    if (
-      Object.prototype.hasOwnProperty.call(
-        mdastNode.children[step].attributes,
-        'title',
-      )
-    ) {
-      setTitle(mdastNode.children[step].attributes['title'] || '');
-    } else {
-      setTitle('');
-    }
-
-    // setTitle
-  }, [step, mdastNode]);
+  }, [mdastNode]);
 
   /**
-   * Moves focus to the step heading once its text reflects the new step,
-   * so NVDA announces the change. Player only - skips the first render so
-   * the initially-active step doesn't steal focus on page load.
+   * Moves focus to the step heading on step change so NVDA announces it.
+   * Player only - skips the first render so the initially-active step
+   * doesn't steal focus on page load.
    */
   useEffect(() => {
-    const isFirstRender = isFirstTitleRenderRef.current;
-    isFirstTitleRenderRef.current = false;
+    const isFirstRender = isFirstStepRenderRef.current;
+    isFirstStepRenderRef.current = false;
 
     if (isFirstRender || !isPlayback) {
       return;
     }
 
     headingRef.current?.focus();
-  }, [title, isPlayback]);
+  }, [step, isPlayback]);
 
   /**
    * UE calculates step count

--- a/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/steps/StepsEditor.tsx
@@ -121,6 +121,8 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
   } = useBackgroundColors(mdastNode?.attributes?.['backgroundColor'] ?? '');
 
   const skipNextCloseRebuildRef = useRef(false);
+  const headingRef = useRef<HTMLElement>(null);
+  const isFirstTitleRenderRef = useRef(true);
 
   const a11yStepProps = (index: number) => ({
     id: `step-${index}`,
@@ -378,6 +380,22 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
   }, [step, mdastNode]);
 
   /**
+   * Moves focus to the step heading once its text reflects the new step,
+   * so NVDA announces the change. Player only - skips the first render so
+   * the initially-active step doesn't steal focus on page load.
+   */
+  useEffect(() => {
+    const isFirstRender = isFirstTitleRenderRef.current;
+    isFirstTitleRenderRef.current = false;
+
+    if (isFirstRender || !isPlayback) {
+      return;
+    }
+
+    headingRef.current?.focus();
+  }, [title, isPlayback]);
+
+  /**
    * UE calculates step count
    */
   useEffect(() => {
@@ -555,7 +573,12 @@ export const StepsEditor: React.FC<DirectiveEditorProps<StepDirectiveNode>> = ({
                     justifyContent: 'center',
                   }}
                 >
-                  <Typography sx={{ padding: 2 }} variant="h2">
+                  <Typography
+                    ref={headingRef}
+                    tabIndex={-1}
+                    sx={{ padding: 2 }}
+                    variant="h2"
+                  >
                     {title}
                   </Typography>
                 </Box>


### PR DESCRIPTION
## Summary

Fixes accessibility issues in the "steps" content block's numbered step controls (CCUI-3065). Screen reader users previously heard the wrong step number (0-based instead of the 1-based numbers shown on screen), got no indication of which step was currently active, had a broken button↔panel relationship, and received no announcement when navigating between steps. All four are now fixed for NVDA and other screen readers.

### Changes

- **Step buttons announce the correct 1-based number**: `ButtonIcon`'s built-in `id`-as-`aria-label` fallback was leaking the raw 0-based `id` (e.g. "step-0") as the spoken name. `StepsEditor.tsx` now passes an explicit `aria-label` (`Step ${index+1}`) through `ButtonIcon`'s `props` bag, which is the only channel that reliably reaches the rendered `<button>`.
- **Active step is announced**: added `aria-current="step"` to the active step button, mirroring the existing visual underline treatment.
- **Button↔panel relationship actually resolves**: `aria-controls` (on the step buttons) and `aria-labelledby` (on the step content panel, in `StepContentEditor.tsx`) previously pointed at ids (`step-panel-N` / `tab-N`) that didn't exist anywhere in the DOM. Also discovered `ButtonIcon` never forwards its `id` prop to the real DOM element at all (only used internally for `aria-label`/`data-testid` fallback) — so `id`/`aria-controls` are now set via the `props` bag as well, so they land as real attributes that match the panel's actual `id="tabpanel-N"`.
- **Focus moves to the step heading on navigation**: clicking a step number, Next, or Back now moves focus to the step's `<h2>` heading once its text has updated to the new step, so NVDA announces the change automatically. `title` is now derived with `useMemo` from `step`/`mdastNode` (rather than a separate `useState` set from an effect), so it's always correct in the same render as `step` — and the focus effect is keyed on `step` itself, so it fires reliably even when two steps share a title or both have none (keying on `title` would silently skip the focus move in that case, since setting state to an unchanged value doesn't trigger the effect). Gated behind `isPlayback` so it only fires for learners in the player, not authors previewing steps in the design tool, and skips the very first render so the initially-active step doesn't steal focus on page load.


### Ticket number CCUI 3065
https://cybercents.atlassian.net/browse/CCUI-3065


## Test plan
- [ ] With NVDA (or another screen reader) running, tab to the step number buttons in a published lesson and confirm each announces "Step 1", "Step 2", etc. — not "step-0", "step-1".
- [ ] Confirm the currently active step's button is announced as current (e.g. "Step 2, current step").
- [ ] Click a step number, then Next, then Back in the player and confirm NVDA automatically announces the new step heading each time, without the user needing to manually navigate to it.
- [ ] In the design-tool editor (not the player), click Next/Back while previewing a steps block and confirm focus does *not* jump to the heading — authoring flow should be unaffected.
- [ ] Reload a lesson on its initially-active step and confirm focus is not stolen from the page on load.
- [ ] Confirm visual behavior is unchanged: step numbers, underline on the active step, and heading text all render exactly as before.
