### PR TITLE
fix: add delete icon to audio/video edit toolbars

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/EditAudioToolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/EditAudioToolbar.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { MdxJsxAttribute, MdxJsxExpressionAttribute } from 'mdast-util-mdx-jsx';
 import { openEditAudioDialog$ } from './index';
-import { usePublisher } from '@mdxeditor/gurx';
+import { usePublisher, useCellValues } from '@mdxeditor/gurx';
+import { readOnly$ } from '@mdxeditor/editor';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $getNodeByKey } from 'lexical';
 import { IconButton, Tooltip } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 
 export interface EditAudioToolbarProps {
   nodeKey: string;
@@ -25,6 +29,8 @@ export function EditAudioToolbar({
   captionSrc,
 }: EditAudioToolbarProps): JSX.Element {
   const openEditAudioDialog = usePublisher(openEditAudioDialog$);
+  const [editor] = useLexicalComposerContext();
+  const [readOnly] = useCellValues(readOnly$);
 
   return (
     <div
@@ -43,6 +49,7 @@ export function EditAudioToolbar({
       <Tooltip title="Edit Audio Settings">
         <IconButton
           size="small"
+          disabled={readOnly}
           onClick={() => {
             openEditAudioDialog({
               nodeKey,
@@ -57,6 +64,21 @@ export function EditAudioToolbar({
           }}
         >
           <EditIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Delete Audio">
+        <IconButton
+          size="small"
+          aria-label="delete"
+          disabled={readOnly}
+          onClick={(e) => {
+            e.preventDefault();
+            editor.update(() => {
+              $getNodeByKey(nodeKey)?.remove();
+            });
+          }}
+        >
+          <DeleteForeverIcon fontSize="small" />
         </IconButton>
       </Tooltip>
     </div>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/EditVideoToolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/EditVideoToolbar.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { MdxJsxAttribute, MdxJsxExpressionAttribute } from 'mdast-util-mdx-jsx';
 import { openEditVideoDialog$ } from './index';
-import { usePublisher } from '@mdxeditor/gurx';
+import { usePublisher, useCellValues } from '@mdxeditor/gurx';
+import { readOnly$ } from '@mdxeditor/editor';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $getNodeByKey } from 'lexical';
 import { IconButton, Tooltip } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import EditIcon from '@mui/icons-material/Edit';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 
 export interface EditVideoToolbarProps {
   nodeKey: string;
@@ -30,6 +34,8 @@ export function EditVideoToolbar({
   captionSrc,
 }: EditVideoToolbarProps): JSX.Element {
   const openEditVideoDialog = usePublisher(openEditVideoDialog$);
+  const [editor] = useLexicalComposerContext();
+  const [readOnly] = useCellValues(readOnly$);
 
   return (
     <div
@@ -48,6 +54,7 @@ export function EditVideoToolbar({
       <Tooltip title="Edit Video Settings">
         <IconButton
           size="small"
+          disabled={readOnly}
           onClick={() => {
             openEditVideoDialog({
               nodeKey,
@@ -64,6 +71,21 @@ export function EditVideoToolbar({
           }}
         >
           <EditIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Delete Video">
+        <IconButton
+          size="small"
+          aria-label="delete"
+          disabled={readOnly}
+          onClick={(e) => {
+            e.preventDefault();
+            editor.update(() => {
+              $getNodeByKey(nodeKey)?.remove();
+            });
+          }}
+        >
+          <DeleteForeverIcon fontSize="small" />
         </IconButton>
       </Tooltip>
     </div>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/EditVideoToolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/video/EditVideoToolbar.tsx
@@ -6,7 +6,6 @@ import { readOnly$ } from '@mdxeditor/editor';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $getNodeByKey } from 'lexical';
 import { IconButton, Tooltip } from '@mui/material';
-import SettingsIcon from '@mui/icons-material/Settings';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 


### PR DESCRIPTION
## Summary

Audio and video clips in the lesson editor now show a Delete icon next to the existing Edit (gear) icon when the clip is selected, matching the pattern already used for images. Previously there was no way to delete an audio or video clip from its toolbar at all.

### Changes

- Add a "Delete Audio" / "Delete Video" icon button to `EditAudioToolbar` and `EditVideoToolbar`, positioned to the right of the existing Edit button, removing the node via `editor.update(() => $getNodeByKey(nodeKey)?.remove())` — the same mechanism `EditImageToolbar` already uses.
- Gate both the Edit and new Delete buttons on the editor's `readOnly$` cell (`disabled={readOnly}`), bringing audio/video in line with the image toolbar's existing read-only handling.

### Ticket CCUI_3097
https://cybercents.atlassian.net/browse/CCUI-3097

## Test plan
- [ ] In the course editor, insert an audio clip, click it to select it, and confirm both Edit and Delete icons appear with Delete to the right of Edit; click Delete and confirm the clip is removed from the lesson.
- [ ] Repeat the same check for a video clip.
- [ ] Confirm Edit still opens the settings dialog and saves correctly for both audio and video (regression check).

