### PR TITLE
fix(cmi5-player): Anim Pause/Play NVDA and slide navigation support (CCUI-3028)

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/Menu/MenuLayout.tsx
+++ b/apps/cc-cmi5-player/src/app/components/Menu/MenuLayout.tsx
@@ -70,6 +70,13 @@ export default function MenuLayout() {
           '--panel-width',
           `${rect.left}px`,
         );
+        // Published for CSS that needs to centre over the slide panel itself
+        // (the fixed slide-control bar). --panel-width alone is only the left
+        // edge, which isn't enough once the split panel narrows the slide.
+        document.documentElement.style.setProperty(
+          '--slide-panel-width',
+          `${rect.width}px`,
+        );
         maxSlideWidth$.value = rect.width;
       }
     };

--- a/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
@@ -408,7 +408,13 @@ function RC5Player() {
     <>
       <Box
         className={themeClass}
-        sx={{ height: '100%' }}
+        sx={{
+          height: '100%',
+          // The slide controls are position:fixed, so they no longer occupy
+          // space in the flow. Reserve room at the bottom so the end of a long
+          // slide can still be scrolled clear of the bar.
+          pb: '72px',
+        }}
         onClick={onClickSlide}
         ref={editorContainerRef}
       >

--- a/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
@@ -20,14 +20,7 @@ import {
   useAnimationPlayback,
 } from './plugins/animation-player';
 import '@mdxeditor/editor/style.css';
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  useRef,
-} from 'react';
+import { useContext, useEffect, useMemo, useState, useRef } from 'react';
 
 import { Box, Typography } from '@mui/material';
 import {
@@ -78,10 +71,10 @@ import { GridContainerDirectiveDescriptor } from './editors/directives/GridConta
 import { GridCellDirectiveDescriptor } from './editors/directives/GridCellDirectiveDescriptor';
 import { mediaEventManager } from '../../utils/MediaEventManager';
 import { logger } from '../../debug';
-import { useDispatch, useSelector } from 'react-redux';
-import { auJsonSel, slideWidth } from '../../redux/auReducer';
-import { setActiveTab } from '../../redux/navigationReducer';
+import { useSelector } from 'react-redux';
+import { slideWidth } from '../../redux/auReducer';
 import SlideControlBar from './SlideControlBar';
+import { useSlideNavigation } from './useSlideNavigation';
 
 /**
  * Rapid CMI5 Visual Editor
@@ -98,8 +91,6 @@ function RC5Player() {
   );
   const [slideAnimations, setSlideAnimations] = useState<AnimationConfig[]>([]);
   const slideWidthSel = useSelector(slideWidth);
-  const auJson = useSelector(auJsonSel);
-  const dispatch = useDispatch();
 
   const { rc5Theme } = useCoursePresentation();
 
@@ -390,19 +381,8 @@ function RC5Player() {
   const { hasAnimations, isPaused, isComplete, toggle, replay } =
     useAnimationPlayback(slideAnimations, activeTab, true);
 
-  // Slide bounds. `slides.length` is the Exit slide's index, so it is a valid
-  // forward target but not a content slide.
-  const slideCount = auJson?.slides?.length ?? 0;
-  const canGoPrevious = activeTab > 0;
-  const canGoNext = activeTab < slideCount;
-
-  const goToPrevious = useCallback(() => {
-    if (activeTab > 0) dispatch(setActiveTab(activeTab - 1));
-  }, [activeTab, dispatch]);
-
-  const goToNext = useCallback(() => {
-    if (activeTab < slideCount) dispatch(setActiveTab(activeTab + 1));
-  }, [activeTab, slideCount, dispatch]);
+  const { canGoPrevious, canGoNext, goToPrevious, goToNext } =
+    useSlideNavigation();
 
   return (
     <>

--- a/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
@@ -114,14 +114,15 @@ function RC5Player() {
   useEffect(() => {
     // Wait for the new slide's editor to finish mounting before focusing
     const id = setTimeout(() => {
-      // Find the root Lexical editor element (first match = outermost = root editor)
+      // Focus the <main> landmark rather than the Lexical editor element inside
+      // it. Both make NVDA read from the top of the slide, but <main> sits
+      // BEFORE the editor's focusables, so a single Shift+Tab from here reaches
+      // the slide controls. Focusing the editor itself put the controls behind
+      // the user's position, effectively burying the WCAG 2.2.2 pause control.
       const el = slideContentRef.current?.querySelector<HTMLElement>(
-        '[data-lexical-editor="true"]',
+        '#main-content',
       );
       if (el) {
-        // tabindex="-1" is required to programmatically focus contenteditable="false"
-        el.setAttribute('tabindex', '-1');
-        // Focus so NVDA reads from the top of the new slide.
         // preventScroll stops the page from jumping visually when focus moves.
         el.focus({ preventScroll: true });
       }
@@ -415,6 +416,13 @@ function RC5Player() {
         {thePlugins && thePlugins.length > 0 && (
           <div role="tabpanel" aria-label="Slide content" ref={slideContentRef}>
             <div id="toc-portal-target" />
+            {/*
+              Slide controls come immediately AFTER the <main> landmark.
+              On slide change focus is placed on <main> (see the effect above),
+              so this ordering makes the controls the very next forward Tab stop
+              — the pause control required by WCAG 2.2.2 is reachable with one
+              Tab instead of being buried behind the slide's content.
+            */}
             {/* Add main landmark for ease of nav and skip link to use */}
             <main id="main-content" tabIndex={-1}>
               <MDXEditor

--- a/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
@@ -20,7 +20,14 @@ import {
   useAnimationPlayback,
 } from './plugins/animation-player';
 import '@mdxeditor/editor/style.css';
-import { useContext, useEffect, useMemo, useState, useRef } from 'react';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react';
 
 import { Box, Typography } from '@mui/material';
 import {
@@ -71,8 +78,10 @@ import { GridContainerDirectiveDescriptor } from './editors/directives/GridConta
 import { GridCellDirectiveDescriptor } from './editors/directives/GridCellDirectiveDescriptor';
 import { mediaEventManager } from '../../utils/MediaEventManager';
 import { logger } from '../../debug';
-import { useSelector } from 'react-redux';
-import { slideWidth } from '../../redux/auReducer';
+import { useDispatch, useSelector } from 'react-redux';
+import { auJsonSel, slideWidth } from '../../redux/auReducer';
+import { setActiveTab } from '../../redux/navigationReducer';
+import SlideControlBar from './SlideControlBar';
 
 /**
  * Rapid CMI5 Visual Editor
@@ -89,6 +98,8 @@ function RC5Player() {
   );
   const [slideAnimations, setSlideAnimations] = useState<AnimationConfig[]>([]);
   const slideWidthSel = useSelector(slideWidth);
+  const auJson = useSelector(auJsonSel);
+  const dispatch = useDispatch();
 
   const { rc5Theme } = useCoursePresentation();
 
@@ -375,7 +386,22 @@ function RC5Player() {
   }, [themeSel]);
 
   // Use the animation playback hook with parsed animations
-  useAnimationPlayback(slideAnimations, activeTab, true);
+  const { hasAnimations, isPaused, isComplete, toggle, replay } =
+    useAnimationPlayback(slideAnimations, activeTab, true);
+
+  // Slide bounds. `slides.length` is the Exit slide's index, so it is a valid
+  // forward target but not a content slide.
+  const slideCount = auJson?.slides?.length ?? 0;
+  const canGoPrevious = activeTab > 0;
+  const canGoNext = activeTab < slideCount;
+
+  const goToPrevious = useCallback(() => {
+    if (activeTab > 0) dispatch(setActiveTab(activeTab - 1));
+  }, [activeTab, dispatch]);
+
+  const goToNext = useCallback(() => {
+    if (activeTab < slideCount) dispatch(setActiveTab(activeTab + 1));
+  }, [activeTab, slideCount, dispatch]);
 
   return (
     <>
@@ -400,6 +426,17 @@ function RC5Player() {
                 key={activeTab}
               />
             </main>
+            <SlideControlBar
+              canGoPrevious={canGoPrevious}
+              canGoNext={canGoNext}
+              onPrevious={goToPrevious}
+              onNext={goToNext}
+              hasAnimations={hasAnimations}
+              isPaused={isPaused}
+              isComplete={isComplete}
+              onTogglePause={toggle}
+              onReplay={replay}
+            />
           </div>
         )}
       </Box>

--- a/apps/cc-cmi5-player/src/app/components/player/SlideControlBar.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/SlideControlBar.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { alpha, Stack, Tooltip, useTheme } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import ReplayIcon from '@mui/icons-material/Replay';
+import {
+  TOOLTIP_ENTER_DELAY,
+  TOOLTIP_ENTER_NEXT_DELAY,
+} from '../Menu/shared';
+
+interface SlideControlBarProps {
+  /** Whether a previous slide exists. */
+  canGoPrevious: boolean;
+  /** Whether a next slide exists. */
+  canGoNext: boolean;
+  onPrevious: () => void;
+  onNext: () => void;
+  /** False on slides with no animations — the motion control is then disabled. */
+  hasAnimations: boolean;
+  isPaused: boolean;
+  /** True once the sequence has finished, so the control offers replay instead. */
+  isComplete: boolean;
+  onTogglePause: () => void;
+  onReplay: () => void;
+}
+
+/**
+ * Bottom-center slide controls: previous/next slide plus animation
+ * pause/resume.
+ *
+ * The pause control exists to satisfy WCAG 2.1 SC 2.2.2 (Pause, Stop, Hide):
+ * slide animations start automatically, and any that run longer than five
+ * seconds must offer the user a way to pause them.
+ *
+ * Keyboard model (per the ticket): the bar is a single tab stop — one Tab
+ * reaches the group, then Left/Right move between the buttons and Escape
+ * returns focus to the slide content, so users don't tab through every button.
+ * This is the standard `role="toolbar"` roving-tabindex pattern from the
+ * WAI-ARIA Authoring Practices.
+ */
+export default function SlideControlBar({
+  canGoPrevious,
+  canGoNext,
+  onPrevious,
+  onNext,
+  hasAnimations,
+  isPaused,
+  isComplete,
+  onTogglePause,
+  onReplay,
+}: SlideControlBarProps) {
+  const { button, palette } = useTheme();
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Index of the button holding tabindex="0" (the group's single tab stop).
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
+  const motionDisabled = !hasAnimations;
+
+  const buttons = [
+    {
+      key: 'previous',
+      label: 'Previous slide',
+      icon: <ArrowBackIosNewIcon fontSize="small" color="inherit" />,
+      onClick: onPrevious,
+      disabled: !canGoPrevious,
+    },
+    isComplete
+      ? {
+          key: 'replay',
+          label: 'Replay animations',
+          icon: <ReplayIcon fontSize="small" color="inherit" />,
+          onClick: onReplay,
+          disabled: motionDisabled,
+        }
+      : {
+          key: 'pause',
+          label: isPaused ? 'Resume animations' : 'Pause animations',
+          icon: isPaused ? (
+            <PlayArrowIcon fontSize="small" color="inherit" />
+          ) : (
+            <PauseIcon fontSize="small" color="inherit" />
+          ),
+          onClick: onTogglePause,
+          disabled: motionDisabled,
+        },
+    {
+      key: 'next',
+      label: 'Next slide',
+      icon: <ArrowForwardIosIcon fontSize="small" color="inherit" />,
+      onClick: onNext,
+      disabled: !canGoNext,
+    },
+  ];
+
+  // Keep the roving tab stop on a button that still exists.
+  useEffect(() => {
+    if (focusedIndex > buttons.length - 1) setFocusedIndex(0);
+  }, [buttons.length, focusedIndex]);
+
+  const focusButtonAt = useCallback((index: number) => {
+    const el = containerRef.current?.querySelectorAll<HTMLButtonElement>(
+      'button[data-slide-control]',
+    );
+    el?.[index]?.focus();
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const lastIndex = buttons.length - 1;
+      let nextIndex: number | null = null;
+
+      switch (event.key) {
+        case 'ArrowRight':
+          nextIndex = focusedIndex >= lastIndex ? 0 : focusedIndex + 1;
+          break;
+        case 'ArrowLeft':
+          nextIndex = focusedIndex <= 0 ? lastIndex : focusedIndex - 1;
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = lastIndex;
+          break;
+        case 'Escape': {
+          // Hand focus back to the slide content, per the ticket's
+          // "escape to tab back to parent".
+          event.preventDefault();
+          const slide = document.getElementById('main-content');
+          slide?.focus({ preventScroll: true });
+          return;
+        }
+        default:
+          return;
+      }
+
+      if (nextIndex === null) return;
+      event.preventDefault();
+      setFocusedIndex(nextIndex);
+      focusButtonAt(nextIndex);
+    },
+    [buttons.length, focusedIndex, focusButtonAt],
+  );
+
+  return (
+    <Stack
+      ref={containerRef}
+      role="toolbar"
+      aria-label="Slide controls"
+      aria-orientation="horizontal"
+      direction="row"
+      spacing={0.5}
+      onKeyDown={handleKeyDown}
+      sx={{
+        position: 'sticky',
+        bottom: 16,
+        zIndex: (theme) => theme.zIndex.appBar + 1,
+        width: 'fit-content',
+        mx: 'auto',
+        mt: 2,
+        mb: 2,
+        px: 1,
+        py: 0.5,
+        alignItems: 'center',
+        borderRadius: '999px',
+        backgroundColor: alpha(palette.background.paper, 0.92),
+        border: `1px solid ${alpha(palette.text.primary, 0.12)}`,
+        boxShadow: 2,
+      }}
+    >
+      {buttons.map((btn, index) => (
+        <Tooltip
+          key={btn.key}
+          title={btn.label}
+          enterDelay={TOOLTIP_ENTER_DELAY}
+          enterNextDelay={TOOLTIP_ENTER_NEXT_DELAY}
+        >
+          {/* span keeps the tooltip working while the button is disabled */}
+          <span>
+            <IconButton
+              data-slide-control
+              data-testid={`slide-control-${btn.key}`}
+              aria-label={btn.label}
+              size="small"
+              disabled={btn.disabled}
+              // Roving tabindex: exactly one button is tabbable at a time.
+              tabIndex={index === focusedIndex ? 0 : -1}
+              onFocus={() => setFocusedIndex(index)}
+              onClick={btn.onClick}
+              sx={{ color: button.iconColor }}
+            >
+              {btn.icon}
+            </IconButton>
+          </span>
+        </Tooltip>
+      ))}
+    </Stack>
+  );
+}

--- a/apps/cc-cmi5-player/src/app/components/player/SlideControlBar.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/SlideControlBar.tsx
@@ -95,10 +95,21 @@ export default function SlideControlBar({
     },
   ];
 
-  // Keep the roving tab stop on a button that still exists.
+  // The roving tab stop must sit on an ENABLED button. A disabled button is not
+  // focusable and is dropped from the accessibility tree, so parking the group's
+  // only tabIndex={0} on one (e.g. "Previous" while on the first slide) would
+  // leave the whole toolbar unreachable by keyboard.
+  const firstEnabledIndex = buttons.findIndex((b) => !b.disabled);
+  const activeIndex =
+    !buttons[focusedIndex] || buttons[focusedIndex].disabled
+      ? firstEnabledIndex
+      : focusedIndex;
+
   useEffect(() => {
-    if (focusedIndex > buttons.length - 1) setFocusedIndex(0);
-  }, [buttons.length, focusedIndex]);
+    if (activeIndex !== focusedIndex && activeIndex >= 0) {
+      setFocusedIndex(activeIndex);
+    }
+  }, [activeIndex, focusedIndex]);
 
   const focusButtonAt = useCallback((index: number) => {
     const el = containerRef.current?.querySelectorAll<HTMLButtonElement>(
@@ -110,20 +121,40 @@ export default function SlideControlBar({
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       const lastIndex = buttons.length - 1;
+
+      // Step over disabled buttons — they can't take focus, so landing on one
+      // would strand the user mid-group.
+      const nextEnabled = (from: number, step: number): number => {
+        for (let i = 1; i <= buttons.length; i++) {
+          const candidate =
+            (from + step * i + buttons.length * i) % buttons.length;
+          if (!buttons[candidate].disabled) return candidate;
+        }
+        return from;
+      };
+      const firstEnabled = (from: number, step: number): number => {
+        for (let i = 0; i < buttons.length; i++) {
+          const candidate = from + step * i;
+          if (candidate < 0 || candidate > lastIndex) break;
+          if (!buttons[candidate].disabled) return candidate;
+        }
+        return activeIndex;
+      };
+
       let nextIndex: number | null = null;
 
       switch (event.key) {
         case 'ArrowRight':
-          nextIndex = focusedIndex >= lastIndex ? 0 : focusedIndex + 1;
+          nextIndex = nextEnabled(activeIndex, 1);
           break;
         case 'ArrowLeft':
-          nextIndex = focusedIndex <= 0 ? lastIndex : focusedIndex - 1;
+          nextIndex = nextEnabled(activeIndex, -1);
           break;
         case 'Home':
-          nextIndex = 0;
+          nextIndex = firstEnabled(0, 1);
           break;
         case 'End':
-          nextIndex = lastIndex;
+          nextIndex = firstEnabled(lastIndex, -1);
           break;
         case 'Escape': {
           // Hand focus back to the slide content, per the ticket's
@@ -142,7 +173,7 @@ export default function SlideControlBar({
       setFocusedIndex(nextIndex);
       focusButtonAt(nextIndex);
     },
-    [buttons.length, focusedIndex, focusButtonAt],
+    [buttons, activeIndex, focusButtonAt],
   );
 
   return (
@@ -186,8 +217,8 @@ export default function SlideControlBar({
               aria-label={btn.label}
               size="small"
               disabled={btn.disabled}
-              // Roving tabindex: exactly one button is tabbable at a time.
-              tabIndex={index === focusedIndex ? 0 : -1}
+              // Roving tabindex: exactly one ENABLED button is tabbable.
+              tabIndex={index === activeIndex ? 0 : -1}
               onFocus={() => setFocusedIndex(index)}
               onClick={btn.onClick}
               sx={{ color: button.iconColor }}

--- a/apps/cc-cmi5-player/src/app/components/player/SlideControlBar.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/SlideControlBar.tsx
@@ -6,10 +6,7 @@ import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import ReplayIcon from '@mui/icons-material/Replay';
-import {
-  TOOLTIP_ENTER_DELAY,
-  TOOLTIP_ENTER_NEXT_DELAY,
-} from '../Menu/shared';
+import { TOOLTIP_ENTER_DELAY, TOOLTIP_ENTER_NEXT_DELAY } from '../Menu/shared';
 
 interface SlideControlBarProps {
   /** Whether a previous slide exists. */
@@ -88,7 +85,7 @@ export default function SlideControlBar({
         },
     {
       key: 'next',
-      label: 'Next slide',
+      label: 'Next Slide',
       icon: <ArrowForwardIosIcon fontSize="small" color="inherit" />,
       onClick: onNext,
       disabled: !canGoNext,
@@ -186,13 +183,21 @@ export default function SlideControlBar({
       spacing={0.5}
       onKeyDown={handleKeyDown}
       sx={{
-        position: 'sticky',
-        bottom: 16,
+        // Pinned to the viewport rather than the content flow. With `sticky` the
+        // bar only pinned once a slide was tall enough to scroll — on shorter
+        // slides it sat wherever the content happened to end, so the controls
+        // appeared to jump between slides. `fixed` keeps them a constant
+        // distance from the bottom regardless of content height.
+        //
+        // Horizontally centred over the slide panel. Both vars are maintained by
+        // a ResizeObserver in MenuLayout, so the bar tracks the collapsible
+        // drawer and the resizable split panel.
+        position: 'fixed',
+        bottom: 24,
+        left: 'calc(var(--panel-width, 0px) + var(--slide-panel-width, 100vw) / 2)',
+        transform: 'translateX(-50%)',
         zIndex: (theme) => theme.zIndex.appBar + 1,
         width: 'fit-content',
-        mx: 'auto',
-        mt: 2,
-        mb: 2,
         px: 1,
         py: 0.5,
         alignItems: 'center',

--- a/apps/cc-cmi5-player/src/app/components/player/plugins/animation-player/useAnimationPlayback.ts
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/animation-player/useAnimationPlayback.ts
@@ -1,5 +1,5 @@
 import { AnimationConfig, AnimationEngine } from '@rapid-cmi5/ui';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
  * Hook for playing animations in the CMI5 player
@@ -11,6 +11,19 @@ export function useAnimationPlayback(
   enabled: boolean = true,
 ) {
   const engineRef = useRef<AnimationEngine | null>(null);
+
+  // Drives the play/pause control. `hasAnimations` lets the UI disable the
+  // control on slides with nothing to pause (WCAG 2.2.2 only applies when
+  // there is moving content).
+  const [isPaused, setIsPaused] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const hasAnimations = Boolean(enabled && animations && animations.length > 0);
+
+  useEffect(() => {
+    // New slide (or new content): start from a clean, un-paused state.
+    setIsPaused(false);
+    setIsComplete(false);
+  }, [animations, slideIndex]);
 
   useEffect(() => {
     // Skip if animations disabled or no animations
@@ -173,6 +186,8 @@ export function useAnimationPlayback(
       },
       onAllComplete: () => {
         console.log('🎉 All animations completed');
+        // Nothing left to pause — the control switches to "replay".
+        setIsComplete(true);
       },
     });
 
@@ -214,8 +229,49 @@ export function useAnimationPlayback(
     };
   }, [animations, slideIndex, enabled]);
 
+  const pause = useCallback(() => {
+    engineRef.current?.pause();
+    setIsPaused(true);
+  }, []);
+
+  const resume = useCallback(() => {
+    engineRef.current?.resume();
+    setIsPaused(false);
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (isPaused) {
+      resume();
+    } else {
+      pause();
+    }
+  }, [isPaused, pause, resume]);
+
+  /**
+   * Replay the slide's animations from the start. Used once the sequence has
+   * finished, when pausing is no longer meaningful.
+   */
+  const replay = useCallback(() => {
+    const engine = engineRef.current;
+    if (!engine) return;
+
+    engine.reset();
+    setIsPaused(false);
+    setIsComplete(false);
+    engine.playAll().catch((error) => {
+      console.error('❌ Error replaying animations:', error);
+    });
+  }, []);
+
   return {
     engine: engineRef.current,
     isPlaying: engineRef.current?.getPlaybackState() === 'playing',
+    hasAnimations,
+    isPaused,
+    isComplete,
+    pause,
+    resume,
+    toggle,
+    replay,
   };
 }

--- a/apps/cc-cmi5-player/src/app/components/player/useSlideNavigation.ts
+++ b/apps/cc-cmi5-player/src/app/components/player/useSlideNavigation.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { auJsonSel } from '../../redux/auReducer';
+import { activeTabSel, setActiveTab } from '../../redux/navigationReducer';
+
+/**
+ * Forward/back slide navigation for the player's slide controls.
+ *
+ * Wraps the `activeTab` Redux slice so components get bounds-checked movement
+ * instead of re-deriving the edge cases. Note `slides.length` is the Exit
+ * slide's index — a valid forward target, but not a content slide.
+ */
+export function useSlideNavigation() {
+  const dispatch = useDispatch();
+  const auJson = useSelector(auJsonSel);
+  const activeTab = useSelector(activeTabSel);
+
+  const slideCount = auJson?.slides?.length ?? 0;
+  const canGoPrevious = activeTab > 0;
+  const canGoNext = activeTab < slideCount;
+
+  const goToPrevious = useCallback(() => {
+    if (activeTab > 0) dispatch(setActiveTab(activeTab - 1));
+  }, [activeTab, dispatch]);
+
+  const goToNext = useCallback(() => {
+    if (activeTab < slideCount) dispatch(setActiveTab(activeTab + 1));
+  }, [activeTab, slideCount, dispatch]);
+
+  return { canGoPrevious, canGoNext, goToPrevious, goToNext };
+}

--- a/packages/ui/src/lib/cmi5/mdx/animation/engine/AnimationEngine.spec.ts
+++ b/packages/ui/src/lib/cmi5/mdx/animation/engine/AnimationEngine.spec.ts
@@ -1,0 +1,132 @@
+import { AnimationEngine } from './AnimationEngine';
+import {
+  AnimationConfig,
+  AnimationTrigger,
+  EntranceEffect,
+  PlaybackState,
+} from '../types/Animation.types';
+
+/**
+ * Covers pause/resume (WCAG 2.2.2). The interesting part is that pausing has to
+ * halt BOTH the CSS animation and the setTimeout that drives sequencing — if
+ * only the CSS freezes, the sequence silently runs ahead of what the user sees.
+ */
+describe('AnimationEngine pause/resume', () => {
+  const makeAnimation = (
+    overrides: Partial<AnimationConfig> = {},
+  ): AnimationConfig =>
+    ({
+      id: 'anim-1',
+      order: 1,
+      targetNodeKey: 'node-1',
+      directiveId: 'directive-1',
+      entranceEffect: EntranceEffect.FADE_IN,
+      trigger: AnimationTrigger.ON_SLIDE_OPEN,
+      duration: 10,
+      delay: 0,
+      enabled: true,
+      ...overrides,
+    }) as AnimationConfig;
+
+  let element: HTMLElement;
+
+  const makeEngine = (animations: AnimationConfig[]) =>
+    new AnimationEngine(animations, { findElement: () => element });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    element = document.createElement('div');
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    element.remove();
+  });
+
+  it('freezes the CSS animation and reports PAUSED', async () => {
+    const engine = makeEngine([makeAnimation()]);
+
+    engine.playAll();
+    await jest.advanceTimersByTimeAsync(100);
+
+    engine.pause();
+
+    expect(engine.getPlaybackState()).toBe(PlaybackState.PAUSED);
+    expect(element.style.animationPlayState).toBe('paused');
+  });
+
+  it('unfreezes the CSS animation on resume', async () => {
+    const engine = makeEngine([makeAnimation()]);
+
+    engine.playAll();
+    await jest.advanceTimersByTimeAsync(100);
+    engine.pause();
+    engine.resume();
+
+    expect(engine.getPlaybackState()).toBe(PlaybackState.PLAYING);
+    expect(element.style.animationPlayState).toBe('');
+  });
+
+  it('does not complete while paused, no matter how much time passes', async () => {
+    const onAllComplete = jest.fn();
+    const engine = new AnimationEngine([makeAnimation({ duration: 1 })], {
+      findElement: () => element,
+      onAllComplete,
+    });
+
+    engine.playAll();
+    await jest.advanceTimersByTimeAsync(100);
+    engine.pause();
+
+    // Well past the 1s duration — a naive implementation would fire here.
+    await jest.advanceTimersByTimeAsync(10000);
+
+    expect(onAllComplete).not.toHaveBeenCalled();
+    expect(engine.getPlaybackState()).toBe(PlaybackState.PAUSED);
+  });
+
+  it('resumes with only the remaining time, not a full restart', async () => {
+    const onAnimationComplete = jest.fn();
+    // 1s total; pause 400ms in leaves 600ms to run.
+    const engine = new AnimationEngine([makeAnimation({ duration: 1 })], {
+      findElement: () => element,
+      onAnimationComplete,
+    });
+
+    engine.playAll();
+    // playAll waits 50ms before starting, so the timeout is armed at t=50.
+    await jest.advanceTimersByTimeAsync(450);
+
+    engine.pause();
+    await jest.advanceTimersByTimeAsync(5000); // paused: nothing advances
+    engine.resume();
+
+    // 300ms into the 600ms remainder — still pending.
+    await jest.advanceTimersByTimeAsync(300);
+    expect(onAnimationComplete).not.toHaveBeenCalled();
+
+    // Past the remainder — now it completes.
+    await jest.advanceTimersByTimeAsync(400);
+    expect(onAnimationComplete).toHaveBeenCalledWith('anim-1');
+  });
+
+  it('ignores pause() when nothing is playing', () => {
+    const engine = makeEngine([makeAnimation()]);
+
+    engine.pause();
+
+    expect(engine.getPlaybackState()).toBe(PlaybackState.IDLE);
+  });
+
+  it('clears the frozen play-state on stop so it cannot leak to the next slide', async () => {
+    const engine = makeEngine([makeAnimation()]);
+
+    engine.playAll();
+    await jest.advanceTimersByTimeAsync(100);
+    engine.pause();
+    engine.stop();
+
+    expect(element.style.animationPlayState).toBe('');
+  });
+});

--- a/packages/ui/src/lib/cmi5/mdx/animation/engine/AnimationEngine.ts
+++ b/packages/ui/src/lib/cmi5/mdx/animation/engine/AnimationEngine.ts
@@ -42,9 +42,37 @@ export class AnimationEngine {
   private animations: AnimationConfig[];
   private options: AnimationEngineOptions;
   private playbackState: PlaybackState = PlaybackState.IDLE;
+
+  /**
+   * Compare the playback state opaquely.
+   *
+   * `playbackState` is mutated by `stop()`/`pause()` while a sequence is parked
+   * on an `await`. TypeScript's control-flow analysis cannot see those external
+   * mutations and narrows the field to whatever it was before the await, making
+   * later `=== STOPPED` checks look impossible (TS2367). Comparing behind a
+   * method call keeps those checks honest.
+   */
+  private currentStateIs(state: PlaybackState): boolean {
+    return this.playbackState === state;
+  }
+
   private currentAnimationIndex = 0;
   private animationTimeouts: Map<string, number> = new Map();
   private animationElements: Map<string, HTMLElement> = new Map();
+
+  /**
+   * Bookkeeping for pause/resume (WCAG 2.2.2).
+   *
+   * Freezing the CSS via `animation-play-state: paused` stops the visuals, but the
+   * `setTimeout`s that drive sequencing keep running — on resume the sequence would
+   * be ahead of what the user sees. So for every in-flight completion timeout we
+   * record when it was armed and for how long, cancel it on pause, and re-arm it
+   * with only the remaining time on resume.
+   */
+  private pendingTimeouts: Map<
+    string,
+    { callback: () => void; armedAt: number; remaining: number }
+  > = new Map();
 
   constructor(
     animations: AnimationConfig[],
@@ -75,6 +103,11 @@ export class AnimationEngine {
     // Play animations based on their triggers
     await this.playAnimationSequence();
 
+    // A pause (or stop) may have landed while the sequence was in flight —
+    // don't clobber that state, and don't report completion for a run the
+    // user deliberately halted.
+    if (this.playbackState !== PlaybackState.PLAYING) return;
+
     this.playbackState = PlaybackState.IDLE;
     this.options.onAllComplete?.();
   }
@@ -103,19 +136,128 @@ export class AnimationEngine {
   }
 
   /**
+   * Resolvers for sequence steps parked by `waitWhilePaused()`.
+   * Drained by `resume()` and by `stop()` (so a stop can't strand the sequence).
+   */
+  private pauseWaiters: Array<() => void> = [];
+
+  /**
+   * Block a sequential step for as long as playback is paused. Returns
+   * immediately when not paused, so the un-paused path is unchanged.
+   */
+  private waitWhilePaused(): Promise<void> {
+    if (this.playbackState !== PlaybackState.PAUSED) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.pauseWaiters.push(resolve);
+    });
+  }
+
+  /** Release every step parked in `waitWhilePaused()`. */
+  private releasePauseWaiters(): void {
+    const waiters = this.pauseWaiters;
+    this.pauseWaiters = [];
+    waiters.forEach((resolve) => resolve());
+  }
+
+  /**
+   * Arm a completion timeout, recording enough to re-arm it after a pause.
+   */
+  private armTimeout(
+    id: string,
+    callback: () => void,
+    remaining: number,
+  ): void {
+    const timeoutId = window.setTimeout(callback, remaining);
+    this.animationTimeouts.set(id, timeoutId);
+    this.pendingTimeouts.set(id, {
+      callback,
+      armedAt: Date.now(),
+      remaining,
+    });
+  }
+
+  /**
+   * Cancel a pending timeout but keep the time it had left, so `resume()` can
+   * re-arm it for exactly the remainder.
+   */
+  private suspendTimeout(id: string): void {
+    const pending = this.pendingTimeouts.get(id);
+    const timeoutId = this.animationTimeouts.get(id);
+    if (!pending || timeoutId === undefined) return;
+
+    clearTimeout(timeoutId);
+    this.animationTimeouts.delete(id);
+
+    const elapsed = Date.now() - pending.armedAt;
+    pending.remaining = Math.max(0, pending.remaining - elapsed);
+  }
+
+  /**
+   * Pause all in-flight animations (WCAG 2.2.2 — Pause, Stop, Hide).
+   *
+   * Freezes the CSS animations where they are and suspends the sequencing
+   * timeouts so nothing advances while paused. Safe to call when idle.
+   */
+  public pause(): void {
+    if (this.playbackState !== PlaybackState.PLAYING) return;
+
+    this.playbackState = PlaybackState.PAUSED;
+
+    this.animationElements.forEach((element) => {
+      element.style.animationPlayState = 'paused';
+    });
+
+    this.pendingTimeouts.forEach((_pending, id) => {
+      this.suspendTimeout(id);
+    });
+
+    debugLog('⏸️ Paused animations', undefined, undefined, 'engine');
+  }
+
+  /**
+   * Resume animations previously halted by `pause()`, picking up from exactly
+   * where they were frozen.
+   */
+  public resume(): void {
+    if (this.playbackState !== PlaybackState.PAUSED) return;
+
+    this.playbackState = PlaybackState.PLAYING;
+
+    this.animationElements.forEach((element) => {
+      element.style.animationPlayState = '';
+    });
+
+    // Re-arm on a copied list: each callback mutates pendingTimeouts on fire.
+    Array.from(this.pendingTimeouts.entries()).forEach(([id, pending]) => {
+      this.armTimeout(id, pending.callback, pending.remaining);
+    });
+
+    this.releasePauseWaiters();
+
+    debugLog('▶️ Resumed animations', undefined, undefined, 'engine');
+  }
+
+  /**
    * Stop all playing animations
    */
   public stop(): void {
     this.playbackState = PlaybackState.STOPPED;
+
+    // Let any step parked by a pause fall through to its STOPPED check,
+    // otherwise stopping while paused would leave the sequence hanging.
+    this.releasePauseWaiters();
 
     // Clear all timeouts
     this.animationTimeouts.forEach((timeoutId) => {
       clearTimeout(timeoutId);
     });
     this.animationTimeouts.clear();
+    this.pendingTimeouts.clear();
 
     // Remove animation classes from all elements
     this.animationElements.forEach((element) => {
+      // Clear any frozen play-state so a pause cannot leak into the next slide
+      element.style.animationPlayState = '';
       this.removeAnimationClasses(element);
     });
     this.animationElements.clear();
@@ -257,7 +399,9 @@ export class AnimationEngine {
         'engine',
       );
       for (const anim of afterDelayAnims) {
-        if (this.playbackState === PlaybackState.STOPPED) break;
+        if (this.currentStateIs(PlaybackState.STOPPED)) break;
+        await this.waitWhilePaused();
+        if (this.currentStateIs(PlaybackState.STOPPED)) break;
         await this.applyAnimation(anim);
       }
     }
@@ -271,7 +415,9 @@ export class AnimationEngine {
         'engine',
       );
       for (const anim of onPreviousCompleteAnims) {
-        if (this.playbackState === PlaybackState.STOPPED) break;
+        if (this.currentStateIs(PlaybackState.STOPPED)) break;
+        await this.waitWhilePaused();
+        if (this.currentStateIs(PlaybackState.STOPPED)) break;
         await this.applyAnimation(anim);
       }
     }
@@ -325,7 +471,7 @@ export class AnimationEngine {
       const totalDuration = (animation.delay + animation.duration) * 1000;
 
       // Handle animation complete
-      const timeoutId = window.setTimeout(() => {
+      const onComplete = () => {
         // Apply exit effect if specified
         if (animation.exitEffect && animation.exitEffect !== ExitEffect.NONE) {
           if (this.options.enableDiagnostics) {
@@ -344,10 +490,19 @@ export class AnimationEngine {
 
         this.options.onAnimationComplete?.(animation.id);
         this.animationTimeouts.delete(animation.id);
+        this.pendingTimeouts.delete(animation.id);
         resolve();
-      }, totalDuration);
+      };
 
-      this.animationTimeouts.set(animation.id, timeoutId);
+      this.armTimeout(animation.id, onComplete, totalDuration);
+
+      // If the user paused before this animation began, start it frozen so it
+      // does not play behind a "paused" control.
+      if (this.playbackState === PlaybackState.PAUSED) {
+        element.style.animationPlayState = 'paused';
+        this.suspendTimeout(animation.id);
+      }
+
       this.options.onAnimationStart?.(animation.id);
     });
   }

--- a/packages/ui/src/lib/cmi5/mdx/animation/engine/AnimationEngine.ts
+++ b/packages/ui/src/lib/cmi5/mdx/animation/engine/AnimationEngine.ts
@@ -529,7 +529,9 @@ export class AnimationEngine {
     // happens at the right moment (delay + duration), then the totalDuration
     // timeout resolves the promise for sequencing.
     const isAppear = animation.entranceEffect === EntranceEffect.APPEAR;
-    const baseDuration = this.options.prefersReducedMotion ? 0 : animation.duration;
+    const baseDuration = this.options.prefersReducedMotion
+      ? 0
+      : animation.duration;
     const baseDelay = this.options.prefersReducedMotion ? 0 : animation.delay;
     const duration = isAppear ? 0.01 : baseDuration;
     const delay = isAppear ? baseDelay + baseDuration : baseDelay;
@@ -619,7 +621,9 @@ export class AnimationEngine {
     if (!directiveElement) {
       console.warn(
         `❌ Could not find element with data-anim-directive-id="${animation.directiveId}"`,
-        'Ensure the :anim{id="' + animation.directiveId + '"} directive exists in the markdown.',
+        'Ensure the :anim{id="' +
+          animation.directiveId +
+          '"} directive exists in the markdown.',
       );
     }
 


### PR DESCRIPTION
# SUMMARY
* Adds centered control bar to allow player to navigate prev/next slide and also start/stop/restart anims
* Closes the WCAG 2.1 SC 2.2.2 (Pause, Stop, Hide) gap

## Testing checklist

- [x] **Pause/resume mid-animation** — on a slide with a long animation (10s), pause part-way and confirm it freezes in place, then resumes from that point rather than restarting. Verify the button becomes **Replay** once the sequence finishes, and is disabled on slides with no animations.
- [ ] **Keyboard (NVDA)** — one Tab reaches the control group, Left/Right move between buttons, Home/End jump to the ends, Escape returns focus to the slide. Confirm button labels announce correctly and the pause/resume label change is picked up.
- [ ] **Slide navigation + state reset** — prev/next move through slides and disable correctly at the first slide and the Exit slide; changing slides while paused starts the new slide un-paused (no frozen animation carried over).