### PR TITLE
fix: match toggle-clock aria-label to visible tooltip text

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/scenario/ScenarioConsoles.tsx
+++ b/apps/cc-cmi5-player/src/app/components/scenario/ScenarioConsoles.tsx
@@ -379,7 +379,10 @@ function ScenarioStatus({
               minWidth: '132px',
             }}
           >
-            <IconButton aria-label="toggle-clock" onClick={toggleClock}>
+            <IconButton
+              aria-label={isClockShowing ? 'Hide Clock' : 'Show Clock'}
+              onClick={toggleClock}
+            >
               <Tooltip
                 arrow
                 enterDelay={500}

--- a/apps/cc-cmi5-player/src/app/components/team-consoles/TeamScenarioExercise.tsx
+++ b/apps/cc-cmi5-player/src/app/components/team-consoles/TeamScenarioExercise.tsx
@@ -321,7 +321,10 @@ function TeamScenarioExercise({
                   minWidth: '132px',
                 }}
               >
-                <IconButton aria-label="toggle-clock" onClick={toggleClock}>
+                <IconButton
+                  aria-label={isClockShowing ? 'Hide Clock' : 'Show Clock'}
+                  onClick={toggleClock}
+                >
                   <Tooltip
                     arrow
                     enterDelay={500}


### PR DESCRIPTION
**Summary**

The clock toggle IconButton's aria-label was a static "toggle-clock" string that never matched its Tooltip text ("Hide Clock"/"Show Clock"), violating WCAG 2.5.3 Label in Name and breaking voice-control activation. Derive the aria-label from isClockShowing so it matches the tooltip in both ScenarioConsoles and TeamScenarioExercise.

Ticket: CCUI-3137