### PR TITLE
fix: select audio component when clicking its native control bar

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
@@ -108,27 +108,30 @@ function AudioComponent({
 
   const containerRef = React.useRef<HTMLDivElement | null>(null);
 
-  const onClick = React.useCallback(
-    (payload: MouseEvent) => {
-      const event = payload;
-      // Check if click is within the container or audio element
-      if (
-        (audioRef.current && audioRef.current.contains(event.target as Node)) ||
-        (containerRef.current &&
-          containerRef.current.contains(event.target as Node))
-      ) {
-        if (event.shiftKey) {
-          setSelected(!isSelected);
-        } else {
-          clearSelection();
-          setSelected(true);
-        }
-        return true;
+  const selectAudio = React.useCallback(
+    (shiftKey: boolean) => {
+      if (shiftKey) {
+        setSelected(!isSelected);
+      } else {
+        clearSelection();
+        setSelected(true);
       }
-      return false;
     },
     [isSelected, setSelected, clearSelection],
   );
+
+  const onClick = React.useCallback((payload: MouseEvent) => {
+    const event = payload;
+    // Selection itself happens via handleContainerClick (wrapper clicks) and
+    // onAudioFocus (clicks on the native control bar) below. This handler
+    // just claims clicks within the component so Lexical doesn't apply its
+    // own default click behavior on top.
+    return !!(
+      (audioRef.current && audioRef.current.contains(event.target as Node)) ||
+      (containerRef.current &&
+        containerRef.current.contains(event.target as Node))
+    );
+  }, []);
 
   React.useEffect(() => {
     const unregister = mergeRegister(
@@ -180,15 +183,25 @@ function AudioComponent({
 
   const isFocused = isSelected;
 
-  const handleWrapperClick = (e: React.MouseEvent) => {
-    // Only handle clicks on the wrapper itself, not on the audio controls
-    if (e.target === containerRef.current) {
-      if (e.shiftKey) {
-        setSelected(!isSelected);
-      } else {
-        clearSelection();
-        setSelected(true);
-      }
+  const handleContainerClick = (e: React.MouseEvent) => {
+    // Handles clicks on the wrapper padding around the audio bar. Clicks on
+    // the bar itself are handled by onAudioFocus below, not here — trying to
+    // intercept those would mean racing the browser's own hit-testing for
+    // its native play/seek/volume controls.
+    selectAudio(e.shiftKey);
+  };
+
+  const onAudioFocus = () => {
+    // Clicking any part of native <audio controls> — the play button, the
+    // seek bar, volume — moves DOM focus onto the <audio> element itself,
+    // regardless of which sub-control was clicked. Selecting here (rather
+    // than trying to catch the click before the control does) means seeking
+    // and the rest of the native control behavior stay completely
+    // untouched. Shift-click multi-select isn't available for clicks
+    // directly on the bar since focus events don't carry modifier keys.
+    if (!isSelected) {
+      clearSelection();
+      setSelected(true);
     }
   };
 
@@ -196,7 +209,7 @@ function AudioComponent({
     <React.Suspense fallback={null}>
       <div
         ref={containerRef}
-        onClick={handleWrapperClick}
+        onClick={handleContainerClick}
         style={{
           position: 'relative',
           display: 'block',
@@ -219,6 +232,7 @@ function AudioComponent({
           ref={audioRef}
           controls
           muted={false}
+          onFocus={onAudioFocus}
           data-audio-id={id}
           data-caption-src={captionSrc}
           data-caption-text={!captionSrc ? captionText : undefined}

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
@@ -120,24 +120,20 @@ function AudioComponent({
     [isSelected, setSelected, clearSelection],
   );
 
-  const onClick = React.useCallback((payload: MouseEvent) => {
-    const event = payload;
-    // Selection itself happens via handleContainerClick (wrapper clicks) and
-    // onAudioFocus (clicks on the native control bar) below. This handler
-    // just claims clicks within the component so Lexical doesn't apply its
-    // own default click behavior on top.
-    return !!(
-      (audioRef.current && audioRef.current.contains(event.target as Node)) ||
-      (containerRef.current &&
-        containerRef.current.contains(event.target as Node))
-    );
-  }, []);
-
   React.useEffect(() => {
     const unregister = mergeRegister(
       editor.registerCommand<MouseEvent>(
         CLICK_COMMAND,
-        onClick,
+        (event) => {
+          // Claims click so Lexical doesn't override selection handled by
+          // handleWrapperClick/onAudioFocus.
+          return !!(
+            (audioRef.current &&
+              audioRef.current.contains(event.target as Node)) ||
+            (containerRef.current &&
+              containerRef.current.contains(event.target as Node))
+          );
+        },
         COMMAND_PRIORITY_LOW,
       ),
       editor.registerCommand(
@@ -179,11 +175,14 @@ function AudioComponent({
     return () => {
       unregister();
     };
-  }, [editor, isSelected, nodeKey, onDelete, onEnter, onEscape, onClick]);
+  }, [editor, isSelected, nodeKey, onDelete, onEnter, onEscape]);
 
   const isFocused = isSelected;
 
-  const handleContainerClick = (e: React.MouseEvent) => {
+  // Clicks were being swallowed by native elements. Focus returning reliably.
+  // The handleWrapperClick and onAudioFocus methods below controls the click
+  // response better fixing focus.
+  const handleWrapperClick = (e: React.MouseEvent) => {
     // Handles clicks on the wrapper padding around the audio bar. Clicks on
     // the bar itself are handled by onAudioFocus below, not here — trying to
     // intercept those would mean racing the browser's own hit-testing for
@@ -200,8 +199,7 @@ function AudioComponent({
     // untouched. Shift-click multi-select isn't available for clicks
     // directly on the bar since focus events don't carry modifier keys.
     if (!isSelected) {
-      clearSelection();
-      setSelected(true);
+      selectAudio(false);
     }
   };
 
@@ -209,7 +207,7 @@ function AudioComponent({
     <React.Suspense fallback={null}>
       <div
         ref={containerRef}
-        onClick={handleContainerClick}
+        onClick={handleWrapperClick}
         style={{
           position: 'relative',
           display: 'block',

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioEditor.tsx
@@ -179,25 +179,18 @@ function AudioComponent({
 
   const isFocused = isSelected;
 
-  // Clicks were being swallowed by native elements. Focus returning reliably.
-  // The handleWrapperClick and onAudioFocus methods below controls the click
-  // response better fixing focus.
+  /* The browser's built-in audio controls were catching clicks
+    before our onClick. Two methods to work around this:
+   - handleWrapperClick: handles clicks on the empty space around the bar
+   - onAudioFocus: handles clicks on the bar itself, by watching for focus
+    instead of the click
+    Note: shift-click to multi-select only works through handleWrapperClick,
+*/
   const handleWrapperClick = (e: React.MouseEvent) => {
-    // Handles clicks on the wrapper padding around the audio bar. Clicks on
-    // the bar itself are handled by onAudioFocus below, not here — trying to
-    // intercept those would mean racing the browser's own hit-testing for
-    // its native play/seek/volume controls.
     selectAudio(e.shiftKey);
   };
 
   const onAudioFocus = () => {
-    // Clicking any part of native <audio controls> — the play button, the
-    // seek bar, volume — moves DOM focus onto the <audio> element itself,
-    // regardless of which sub-control was clicked. Selecting here (rather
-    // than trying to catch the click before the control does) means seeking
-    // and the rest of the native control behavior stay completely
-    // untouched. Shift-click multi-select isn't available for clicks
-    // directly on the bar since focus events don't carry modifier keys.
     if (!isSelected) {
       selectAudio(false);
     }

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/EditAudioToolbar.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/EditAudioToolbar.tsx
@@ -36,13 +36,17 @@ export function EditAudioToolbar({
     <div
       style={{
         position: 'absolute',
-        top: '8px',
+        // Floats above the box, nudged down to overlap the border/padding a
+        // bit rather than sitting apart from it — but stays clear of the
+        // native audio controls, which start below the container's 8px
+        // top padding.
+        bottom: 'calc(100% - 16px)',
         right: '8px',
         display: 'flex',
         gap: '4px',
         backgroundColor: 'rgba(255, 255, 255, 0.9)',
         borderRadius: '4px',
-        padding: '4px',
+        padding: '2px',
         boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
       }}
     >


### PR DESCRIPTION
## Summary

Clicking on an audio component's native controls — the play button, seek bar, or volume — now
correctly selects it and shows the edit toolbar (settings/delete). Previously only clicking the
padding around the control bar worked; clicks landing on the bar itself were silently swallowed
by the browser's native `<audio controls>` widget, so learners' authors had to hunt for the
right spot to click before they could edit or delete an audio block. Fixes CCUI-3098.

### Changes

- `AudioComponent` (`AudioEditor.tsx`) now selects the node on `focus` of the `<audio>` element,
  not just on click of the surrounding wrapper. Clicking any part of native media controls moves
  DOM focus onto the `<audio>` element regardless of which sub-control was hit, which sidesteps
  the browser consuming click/mousedown events inside its own shadow-DOM control internals before
  they can bubble out to our handlers.
- Extracted the select/toggle logic into a shared `selectAudio(shiftKey)` helper, called from
  both the wrapper's click handler and the new focus handler, so the two paths stay in sync.
- The `CLICK_COMMAND` handler registered with Lexical no longer performs selection itself (that
  caused a double-toggle risk on shift-click once the focus path was added) — it now only claims
  the event so Lexical skips its own default click handling.

### Ticket CCUI_3098
https://cybercents.atlassian.net/browse/CCUI-3098

## Test plan
- [ ] Insert an audio block, click directly on the play/pause button — edit toolbar appears
- [ ] Click and drag the seek bar to scrub — playback seeks normally, with no change in
  sensitivity or hit area
- [ ] Click the volume control — edit toolbar appears, volume still adjusts normally
- [ ] Click the padding around the audio bar (not on the controls) — edit toolbar still appears
  as before
- [ ] Shift-click the padding around two different audio blocks — both stay selected
  (multi-select via the wrapper path still works)
- [ ] Insert a video and an image block nearby, confirm their selection/toolbar behavior is
  unaffected (no shared-code regression)
