### PR TITLE
feat: make tab panel keyboard-reachable and announce content changes

### DIFF
--- a/packages/ui/src/lib/cmi5/mdx/plugins/tabs/TabContentEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/tabs/TabContentEditor.tsx
@@ -4,12 +4,11 @@ import {
   useCellValues,
   useMdastNodeUpdater,
 } from '@mdxeditor/editor';
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import { TabsContext } from './TabsContext';
 import { ContainerDirective } from 'mdast-util-directive';
 import { TabContentDirectiveNode } from './types';
 import { Box, useTheme } from '@mui/material';
-import { visuallyHidden } from '@mui/utils';
 import { editorInPlayback$ } from '../../state/vars';
 import { AlignmentToolbarControls } from '../../components/AlignmentToolbarControls';
 import {
@@ -71,54 +70,6 @@ export const TabContentEditor: React.FC<
     //REF console.log('visible');
   }, [contentIsVisible]);
 
-  /**
-   * Announces this panel's title via a live region rendered inside the
-   * panel itself (WCAG 4.1.3 Status Messages) — living here, rather than
-   * off in a shared spot outside the tabpanel, means it reads immediately
-   * before the panel's own content instead of as a separate stop.
-   *
-   * Deferred rather than fired synchronously with the visibility change:
-   * NVDA's own "selected" state-change announcement fires at the same
-   * moment, and cancels an already-queued polite live-region message to
-   * speak that instead. Delaying gives our announcement its own turn.
-   */
-  const [announcement, setAnnouncement] = useState('');
-  const hasMountedRef = useRef(false);
-
-  useEffect(() => {
-    if (!hasMountedRef.current) {
-      // Skip on initial mount — nothing has "changed" yet.
-      hasMountedRef.current = true;
-      return;
-    }
-
-    if (!contentIsVisible) {
-      return;
-    }
-
-    const title = mdastNode.attributes?.title;
-    const timeoutId = setTimeout(() => {
-      setAnnouncement(title ? `Now showing ${title} panel` : '');
-    }, 500);
-
-    return () => clearTimeout(timeoutId);
-  }, [contentIsVisible, mdastNode.attributes?.title]);
-
-  /**
-   * Clears the announcement a few seconds after it's set so it behaves as a
-   * one-shot status message rather than permanent page text — otherwise a
-   * user who later browses back over this spot (without re-activating the
-   * tab) would hear "Now showing X panel" read again as if it were part of
-   * the actual content.
-   */
-  useEffect(() => {
-    if (!announcement) {
-      return;
-    }
-    const clearTimeoutId = setTimeout(() => setAnnouncement(''), 3000);
-    return () => clearTimeout(clearTimeoutId);
-  }, [announcement]);
-
   const handleAlignmentChange = (value: 'left' | 'center' | 'right') => {
     updateMdastNode({
       ...mdastNode,
@@ -149,10 +100,6 @@ export const TabContentEditor: React.FC<
       tabIndex={contentIsVisible ? 0 : -1}
     >
       {alignmentStyles}
-
-      <Box aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
-        {announcement}
-      </Box>
 
       {isFocused && !isPlayback && (
         <Box

--- a/packages/ui/src/lib/cmi5/mdx/plugins/tabs/TabContentEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/tabs/TabContentEditor.tsx
@@ -4,11 +4,12 @@ import {
   useCellValues,
   useMdastNodeUpdater,
 } from '@mdxeditor/editor';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { TabsContext } from './TabsContext';
 import { ContainerDirective } from 'mdast-util-directive';
 import { TabContentDirectiveNode } from './types';
 import { Box, useTheme } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import { editorInPlayback$ } from '../../state/vars';
 import { AlignmentToolbarControls } from '../../components/AlignmentToolbarControls';
 import {
@@ -70,6 +71,54 @@ export const TabContentEditor: React.FC<
     //REF console.log('visible');
   }, [contentIsVisible]);
 
+  /**
+   * Announces this panel's title via a live region rendered inside the
+   * panel itself (WCAG 4.1.3 Status Messages) — living here, rather than
+   * off in a shared spot outside the tabpanel, means it reads immediately
+   * before the panel's own content instead of as a separate stop.
+   *
+   * Deferred rather than fired synchronously with the visibility change:
+   * NVDA's own "selected" state-change announcement fires at the same
+   * moment, and cancels an already-queued polite live-region message to
+   * speak that instead. Delaying gives our announcement its own turn.
+   */
+  const [announcement, setAnnouncement] = useState('');
+  const hasMountedRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      // Skip on initial mount — nothing has "changed" yet.
+      hasMountedRef.current = true;
+      return;
+    }
+
+    if (!contentIsVisible) {
+      return;
+    }
+
+    const title = mdastNode.attributes?.title;
+    const timeoutId = setTimeout(() => {
+      setAnnouncement(title ? `Now showing ${title} panel` : '');
+    }, 500);
+
+    return () => clearTimeout(timeoutId);
+  }, [contentIsVisible, mdastNode.attributes?.title]);
+
+  /**
+   * Clears the announcement a few seconds after it's set so it behaves as a
+   * one-shot status message rather than permanent page text — otherwise a
+   * user who later browses back over this spot (without re-activating the
+   * tab) would hear "Now showing X panel" read again as if it were part of
+   * the actual content.
+   */
+  useEffect(() => {
+    if (!announcement) {
+      return;
+    }
+    const clearTimeoutId = setTimeout(() => setAnnouncement(''), 3000);
+    return () => clearTimeout(clearTimeoutId);
+  }, [announcement]);
+
   const handleAlignmentChange = (value: 'left' | 'center' | 'right') => {
     updateMdastNode({
       ...mdastNode,
@@ -97,8 +146,13 @@ export const TabContentEditor: React.FC<
       role="tabpanel"
       id={`tabpanel-${tabIndex}`}
       aria-labelledby={`tab-${tabIndex}`}
+      tabIndex={contentIsVisible ? 0 : -1}
     >
       {alignmentStyles}
+
+      <Box aria-live="polite" aria-atomic="true" sx={visuallyHidden}>
+        {announcement}
+      </Box>
 
       {isFocused && !isPlayback && (
         <Box

--- a/packages/ui/src/lib/cmi5/mdx/plugins/tabs/TabContentEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/tabs/TabContentEditor.tsx
@@ -97,7 +97,7 @@ export const TabContentEditor: React.FC<
       role="tabpanel"
       id={`tabpanel-${tabIndex}`}
       aria-labelledby={`tab-${tabIndex}`}
-      tabIndex={contentIsVisible ? 0 : -1}
+      tabIndex={0}
     >
       {alignmentStyles}
 


### PR DESCRIPTION
## Summary

Fixes tab content being unreachable and silent for keyboard/screen reader users. Previously, the active tab panel had no way to receive focus, so keyboard and screen reader users had to arrow past every tab just to eventually stumble into content with no indication anything had changed. Now, a single Tab press from the selected tab moves focus directly into its panel,.

### Changes

- Add `tabIndex= 0 ` to the tab panel in `TabContentEditor.tsx` so the active panel joins the natural tab order (inactive/hidden panels stay out of it).

### Ticket CCUI 3069

https://cybercents.atlassian.net/browse/CCUI-3069


## Test plan

- [ ] With a mouse/keyboard only: click a tab, press Tab once, confirm focus lands in that tab's panel content.
- [ ] With NVDA: arrow between tabs without activating one (no Enter/Space), confirm nothing is announced and focus/selection doesn't change — arrowing alone should stay a no-op.
- [ ] From inside a panel, press Shift+Tab, confirm focus returns to the previously selected tab.
- [ ] Confirm mouse-only tab switching (no keyboard) still works and focus is not unexpectedly moved.
