### PR TITLE
fix: remove false-positive scrollbar in project selection doc modals

### DIFF
--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/ProjectSelection/Dialogs/DocumentationDialog.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/ProjectSelection/Dialogs/DocumentationDialog.tsx
@@ -193,6 +193,9 @@ export default function DocumentationDialog({
               textDecoration: 'underline',
             },
           },
+          '& > *:last-child': {
+            mb: 0,
+          },
         }}
       >
         <ReactMarkdown remarkPlugins={[remarkGfm]}>


### PR DESCRIPTION
## Summary

Fixed the informational modals shown when clicking the "?" icon on the project selection screen (Clone Git Repository, Open Existing Project, Create New Project) so scrollbars only appear when content actually needs to scroll. Previously, the "Clone Git Repository" and "Create New Project" modals showed a scrollbar even though all of their content fit within the dialog.

### Changes

- Added `'& > *:last-child': { mb: 0 }` to the `DialogContent` sx in `DocumentationDialog.tsx` to zero out the trailing bottom margin on the last rendered markdown element. That trailing margin was counting toward `scrollHeight`, causing the dialog to falsely report overflow (and render a scrollbar) even when the visible content fit comfortably within the fixed 500px dialog height.

### Ticket 3072
https://cybercents.atlassian.net/browse/CCUI-3072

## Test plan
- [ ] Open the project selection screen and click "?" on "Clone Git Repository" — confirm no scrollbar appears (content is short and now fits without one).
- [ ] Click "?" on "Create New Project" — confirm no scrollbar appears.
- [ ] Click "?" on "Open Existing Project" — confirm the scrollbar still appears and still scrolls correctly (this content is long enough to genuinely overflow).
- [ ] Scroll "Open Existing Project" to the bottom and confirm the last line of text isn't clipped and there's no unusual extra whitespace.


