### PR TITLE
fix: give file download links a single accessible control

### DIFF
--- a/packages/ui/src/lib/inputs/file-download/FileDownloadLink.tsx
+++ b/packages/ui/src/lib/inputs/file-download/FileDownloadLink.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Stack, Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import { DownloadFileData } from '@rapid-cmi5/cmi5-build-common';
 import { useEffect, useState } from 'react';
 
@@ -28,17 +28,6 @@ export const FileDownloadLink = ({
 }) => {
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
 
-  const handleDownload = () => {
-    if (blobUrl) {
-      const link = document.createElement('a');
-      link.href = blobUrl;
-      link.download = fileData.name;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    }
-  };
-
   useEffect(() => {
     const loadFile = async () => {
       if (getLinkUrl) {
@@ -64,10 +53,13 @@ export const FileDownloadLink = ({
     <>
       {blobUrl && (
         <Stack direction="row" sx={{ display: 'flex', alignItems: 'center' }}>
-          <IconButton onClick={handleDownload}>
-            <FilePresentIcon />
-          </IconButton>
-          <a href={`${blobUrl}`} download={fileData.name}>
+          <a
+            href={`${blobUrl}`}
+            download={fileData.name}
+            aria-label={`Download ${fileData.name}`}
+            style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+          >
+            <FilePresentIcon aria-hidden="true" />
             {fileData.name}
           </a>
         </Stack>

--- a/packages/ui/src/lib/inputs/file-download/FileDownloadLink.tsx
+++ b/packages/ui/src/lib/inputs/file-download/FileDownloadLink.tsx
@@ -52,7 +52,10 @@ export const FileDownloadLink = ({
     // eslint-disable-next-line react/jsx-no-useless-fragment
     <>
       {blobUrl && (
-        <Stack direction="row" sx={{ display: 'flex', alignItems: 'center' }}>
+        <Stack
+          direction="row"
+          sx={{ display: 'flex', alignItems: 'center', my: '8px' }}
+        >
           <a
             href={`${blobUrl}`}
             download={fileData.name}


### PR DESCRIPTION
## Summary

The file download links (used in both the course editor preview and the live player) now expose a single accessible control per file instead of two silent, redundant ones. Screen reader users hear "Download {filename}, link" — announcing both the action and the target — instead of an unlabeled button and a bare filename link that did the same thing.

### Changes

- `FileDownloadLink.tsx`: removed the duplicate `IconButton`/`handleDownload` that recreated the same download action already handled by the adjacent `<a>` tag.
- `FileDownloadLink.tsx`: moved the `FilePresentIcon` inside the single remaining link, marked `aria-hidden` so it stays a decorative visual cue for sighted users without being exposed as its own control.
- `FileDownloadLink.tsx`: added `aria-label="Download {filename}"` to the link so its accessible name states the action, not just the filename.

### Ticket: CCUI-3076
https://cybercents.atlassian.net/browse/CCUI-3076

## Test plan
- [ ] In the player, tab to a File activity slide and confirm each file is reachable with a single Tab stop (no separate button + link).
- [ ] With a screen reader (NVDA), confirm each control announces as "Download {filename}, link" rather than a silent "button" followed by a bare filename link.
- [ ] Click/activate the link and confirm the file still downloads correctly (blob URL path, both in editor preview and live player).
- [ ] Confirm the paperclip icon still renders visually next to the filename for sighted users.
- [ ] Run WAVE against a File slide and confirm the prior "Empty button" error and duplicate-control alert are gone (contrast errors and Word-doc-format alerts are tracked separately in the new follow-up ticket).

