### PR TITLE
feat: restore focus to video after exiting fullscreen

### DIFF
--- a/apps/cc-cmi5-player/src/app/utils/MediaEventManager.ts
+++ b/apps/cc-cmi5-player/src/app/utils/MediaEventManager.ts
@@ -406,6 +406,13 @@ export class MediaEventManager {
         : 'video_fullscreen_exit';
 
       sendSlideEventVerb(slideNumber, eventType, slideName);
+
+      // Restore focus to the video on exit (Esc, native exit-fullscreen
+      // button, F11, etc. all land here via fullscreenElement going null),
+      // otherwise NVDA loses its place after fullscreen closes.
+      if (!isFullscreen) {
+        video.focus();
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

Video content in course playback now keeps keyboard/screen-reader focus after fullscreen playback ends. Previously, exiting fullscreen (via Esc, the native exit-fullscreen button, or F11) dropped focus, causing NVDA to lose its place in the slide. Focus now returns to the video element itself.

### Changes

- `MediaEventManager.attachVideoListeners` now calls `video.focus()` inside the existing `fullscreenchange` listener when `document.fullscreenElement` clears, restoring focus regardless of how fullscreen was exited.
-- No new listener or ref was introduced — the fix reuses the per-video `fullscreenchange` handler that was already attached for xAPI fullscreen-enter/exit tracking.

### Ticket: CCUI-3082
https://cybercents.atlassian.net/browse/CCUI-3082

## Test plan
- [ ] Focus mode: tab to a video, enter fullscreen, exit via Esc — confirm focus lands on the video element (not the last-focused native control, e.g. volume slider)
- [ ] Same sequence, but exit via the native player's exit-fullscreen button — confirm focus still returns to the video in both cases
- [ ] Browse mode: repeat the sequence, then arrow forward — confirm navigation continues from the video rather than jumping into the slide tablist
- [ ] Verify NVDA's announcement on landing back on the video is clear and matches the video's accessible name
- [ ] Confirm existing `video_fullscreen_enter`/`video_fullscreen_exit` xAPI tracking still fires correctly in console/devtools (regression check on the listener this change extends)
