### PR TITLE
Feat/cc UI 3074 have announcement for scrubber bar

### DIFF
--- a/apps/cc-cmi5-player/src/styles.css
+++ b/apps/cc-cmi5-player/src/styles.css
@@ -29,6 +29,19 @@ a:visited {
   color: #6f96ff;
 }
 
+/* Visually hidden but still announced to screen readers (e.g. ARIA live regions) */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Skip to main content link - visually hidden until focused */
 .skip-link {
   position: absolute;

--- a/apps/rapid-cmi5-electron-frontend/src/styles.css
+++ b/apps/rapid-cmi5-electron-frontend/src/styles.css
@@ -110,6 +110,19 @@ div#horizontalgap {
   width: 0px;
 }
 
+/* Visually hidden but still announced to screen readers (e.g. ARIA live regions) */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Skip to main content link - visually hidden until focused */
 .skip-link {
   position: absolute;

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ClosedCaptionIcon from '@mui/icons-material/ClosedCaption';
+import { useLiveAnnouncer, LiveStatusRegion } from '@rapid-cmi5/ui';
 import { parseTranscript, VttCue } from './parseVtt';
 import styles from './styles/audio-plugin.module.css';
 
@@ -70,23 +71,8 @@ export function AudioTranscript({
   const [expanded, setExpanded] = React.useState<boolean>(false);
   // Announces cue-driven seeks to assistive tech. The native <audio> scrubber
   // is shadow DOM we can't attach ARIA to, so clicking a cue moves playback
-  // silently for a non-sighted user (WCAG 4.1.3). We write directly to this
-  // node (rather than via React state) so re-clicking the same cue —
-  // identical text — still triggers a fresh announcement instead of being
-  // deduped as an unchanged live region.
-  const announceRef = React.useRef<HTMLSpanElement>(null);
-  const announceSeek = React.useCallback((seconds: number) => {
-    const node = announceRef.current;
-    if (!node) {
-      return;
-    }
-    node.textContent = '';
-    requestAnimationFrame(() => {
-      if (announceRef.current) {
-        announceRef.current.textContent = `Jumped to ${formatTime(seconds)}`;
-      }
-    });
-  }, []);
+  // silently for a non-sighted user (WCAG 4.1.3).
+  const { ref: announceRef, announce } = useLiveAnnouncer<HTMLSpanElement>();
 
   const legacyText =
     typeof fallbackText === 'string' && fallbackText.trim() !== ''
@@ -161,7 +147,7 @@ export function AudioTranscript({
     if (audio) {
       audio.currentTime = cue.start;
     }
-    announceSeek(cue.start);
+    announce(`Jumped to ${formatTime(cue.start)}`);
   };
 
   const hasCues = cues.length > 0;
@@ -182,16 +168,7 @@ export function AudioTranscript({
       >
         <ToggleLabel expanded={expanded} />
       </button>
-      {expanded && hasCues && (
-        /* Visually hidden; announces the seek target for screen reader
-           users when a cue button is activated. */
-        <span
-          ref={announceRef}
-          role="status"
-          aria-live="polite"
-          className={styles.visuallyHidden}
-        />
-      )}
+      {expanded && hasCues && <LiveStatusRegion announceRef={announceRef} />}
       {expanded &&
         (hasCues ? (
           <ol className={styles.transcriptList}>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
@@ -72,7 +72,7 @@ export function AudioTranscript({
   // Announces cue-driven seeks to assistive tech. The native <audio> scrubber
   // is shadow DOM we can't attach ARIA to, so clicking a cue moves playback
   // silently for a non-sighted user (WCAG 4.1.3).
-  const { ref: announceRef, announce } = useLiveAnnouncer<HTMLSpanElement>();
+  const { ref: announceRef, announce } = useLiveAnnouncer();
 
   const legacyText =
     typeof fallbackText === 'string' && fallbackText.trim() !== ''

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/AudioTranscript.tsx
@@ -68,6 +68,25 @@ export function AudioTranscript({
   const [text, setText] = React.useState<string>('');
   const [activeIndex, setActiveIndex] = React.useState<number>(-1);
   const [expanded, setExpanded] = React.useState<boolean>(false);
+  // Announces cue-driven seeks to assistive tech. The native <audio> scrubber
+  // is shadow DOM we can't attach ARIA to, so clicking a cue moves playback
+  // silently for a non-sighted user (WCAG 4.1.3). We write directly to this
+  // node (rather than via React state) so re-clicking the same cue —
+  // identical text — still triggers a fresh announcement instead of being
+  // deduped as an unchanged live region.
+  const announceRef = React.useRef<HTMLSpanElement>(null);
+  const announceSeek = React.useCallback((seconds: number) => {
+    const node = announceRef.current;
+    if (!node) {
+      return;
+    }
+    node.textContent = '';
+    requestAnimationFrame(() => {
+      if (announceRef.current) {
+        announceRef.current.textContent = `Jumped to ${formatTime(seconds)}`;
+      }
+    });
+  }, []);
 
   const legacyText =
     typeof fallbackText === 'string' && fallbackText.trim() !== ''
@@ -142,6 +161,7 @@ export function AudioTranscript({
     if (audio) {
       audio.currentTime = cue.start;
     }
+    announceSeek(cue.start);
   };
 
   const hasCues = cues.length > 0;
@@ -162,6 +182,16 @@ export function AudioTranscript({
       >
         <ToggleLabel expanded={expanded} />
       </button>
+      {expanded && hasCues && (
+        /* Visually hidden; announces the seek target for screen reader
+           users when a cue button is activated. */
+        <span
+          ref={announceRef}
+          role="status"
+          aria-live="polite"
+          className={styles.visuallyHidden}
+        />
+      )}
       {expanded &&
         (hasCues ? (
           <ol className={styles.transcriptList}>

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/styles/audio-plugin.module.css
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/styles/audio-plugin.module.css
@@ -94,15 +94,3 @@
   flex: 1 1 auto;
   white-space: pre-wrap;
 }
-
-.visuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}

--- a/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/styles/audio-plugin.module.css
+++ b/packages/rapid-cmi5/src/lib/design-tools/rapidcmi5_mdx/plugins/audio/styles/audio-plugin.module.css
@@ -94,3 +94,15 @@
   flex: 1 1 auto;
   white-space: pre-wrap;
 }
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,7 @@ export { config } from './lib/environments/FrontendEnvironment.env';
 
 export * from './lib/navigation/paging/paginationFiltersConstants';
 export * from './lib/accessibility/HiddenHeader';
+export * from './lib/accessibility/LiveStatusRegion';
 export * from './lib/apps/AppLogo';
 export * from './lib/apps/RapidCmi5Icon';
 export * from './lib/apps/RapidCmi5Title';
@@ -26,6 +27,7 @@ export * from './lib/dashboards/constants';
 export * from './lib/data-display/OverflowTypography';
 export * from './lib/data-display/ListView';
 export * from './lib/hooks/useBackgroundColors';
+export * from './lib/hooks/useLiveAnnouncer';
 export * from './lib/hooks/useDisplayDateFormatter';
 export * from './lib/hooks/useDisplayFocus';
 export * from './lib/hooks/useItemVisibleInBounds';

--- a/packages/ui/src/lib/accessibility/LiveStatusRegion.tsx
+++ b/packages/ui/src/lib/accessibility/LiveStatusRegion.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const visuallyHiddenStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  margin: -1,
+  padding: 0,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
+/**
+ * A visually-hidden `role="status"` live region. Pair with the `ref` returned
+ * by `useLiveAnnouncer` (passed here as `announceRef`) to announce text to
+ * screen readers without any visible UI.
+ */
+export function LiveStatusRegion({
+  announceRef,
+}: {
+  announceRef: React.RefObject<HTMLSpanElement>;
+}) {
+  return (
+    <span
+      ref={announceRef}
+      role="status"
+      aria-live="polite"
+      style={visuallyHiddenStyle}
+    />
+  );
+}
+
+export default LiveStatusRegion;

--- a/packages/ui/src/lib/accessibility/LiveStatusRegion.tsx
+++ b/packages/ui/src/lib/accessibility/LiveStatusRegion.tsx
@@ -1,17 +1,5 @@
 import React from 'react';
 
-const visuallyHiddenStyle: React.CSSProperties = {
-  position: 'absolute',
-  width: 1,
-  height: 1,
-  margin: -1,
-  padding: 0,
-  overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-  whiteSpace: 'nowrap',
-  border: 0,
-};
-
 /**
  * A visually-hidden `role="status"` live region. Pair with the `ref` returned
  * by `useLiveAnnouncer` (passed here as `announceRef`) to announce text to
@@ -27,7 +15,7 @@ export function LiveStatusRegion({
       ref={announceRef}
       role="status"
       aria-live="polite"
-      style={visuallyHiddenStyle}
+      className="visually-hidden"
     />
   );
 }

--- a/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
+++ b/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ClosedCaptionIcon from '@mui/icons-material/ClosedCaption';
 import { AuContextProps } from '@rapid-cmi5/cmi5-build-common';
+import { useLiveAnnouncer } from '../../../hooks/useLiveAnnouncer';
+import { LiveStatusRegion } from '../../../accessibility/LiveStatusRegion';
 
 /**
  * A single parsed WebVTT cue.
@@ -160,23 +162,8 @@ export default function MDAudio(
   const audioRef = React.useRef<HTMLAudioElement>(null);
   // Announces cue-driven seeks to assistive tech. The native <audio> scrubber
   // is shadow DOM we can't attach ARIA to, so clicking a transcript cue moves
-  // playback silently for a non-sighted user (WCAG 4.1.3). We write directly
-  // to this node (rather than via React state) so re-clicking the same cue —
-  // identical text — still triggers a fresh announcement instead of being
-  // deduped as an unchanged live region.
-  const announceRef = React.useRef<HTMLSpanElement>(null);
-  const announceSeek = React.useCallback((seconds: number) => {
-    const node = announceRef.current;
-    if (!node) {
-      return;
-    }
-    node.textContent = '';
-    requestAnimationFrame(() => {
-      if (announceRef.current) {
-        announceRef.current.textContent = `Jumped to ${formatTime(seconds)}`;
-      }
-    });
-  }, []);
+  // playback silently for a non-sighted user (WCAG 4.1.3).
+  const { ref: announceRef, announce } = useLiveAnnouncer<HTMLSpanElement>();
   const [cues, setCues] = React.useState<VttCue[]>([]);
   const [text, setText] = React.useState<string>(legacyText);
   const [activeIndex, setActiveIndex] = React.useState<number>(-1);
@@ -311,26 +298,7 @@ export default function MDAudio(
               aria-label="Transcript"
               style={{ display: 'block' }}
             >
-              {hasCues && (
-                /* Visually hidden; announces the seek target for screen
-                   reader users when a cue button is activated. */
-                <span
-                  ref={announceRef}
-                  role="status"
-                  aria-live="polite"
-                  style={{
-                    position: 'absolute',
-                    width: 1,
-                    height: 1,
-                    margin: -1,
-                    padding: 0,
-                    overflow: 'hidden',
-                    clip: 'rect(0, 0, 0, 0)',
-                    whiteSpace: 'nowrap',
-                    border: 0,
-                  }}
-                />
-              )}
+              {hasCues && <LiveStatusRegion announceRef={announceRef} />}
               {hasCues ? (
                 <ol style={{ listStyle: 'none', padding: 0, marginTop: 4 }}>
                   {cues.map((cue, index) => (
@@ -341,7 +309,7 @@ export default function MDAudio(
                         if (audioRef.current) {
                           audioRef.current.currentTime = cue.start;
                         }
-                        announceSeek(cue.start);
+                        announce(`Jumped to ${formatTime(cue.start)}`);
                       }}
                       style={{
                         display: 'flex',

--- a/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
+++ b/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
@@ -163,7 +163,7 @@ export default function MDAudio(
   // Announces cue-driven seeks to assistive tech. The native <audio> scrubber
   // is shadow DOM we can't attach ARIA to, so clicking a transcript cue moves
   // playback silently for a non-sighted user (WCAG 4.1.3).
-  const { ref: announceRef, announce } = useLiveAnnouncer<HTMLSpanElement>();
+  const { ref: announceRef, announce } = useLiveAnnouncer();
   const [cues, setCues] = React.useState<VttCue[]>([]);
   const [text, setText] = React.useState<string>(legacyText);
   const [activeIndex, setActiveIndex] = React.useState<number>(-1);

--- a/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
+++ b/packages/ui/src/lib/cmi5/markdown/components/MDAudio.tsx
@@ -158,6 +158,25 @@ export default function MDAudio(
     node?.properties?.autoplay !== false;
 
   const audioRef = React.useRef<HTMLAudioElement>(null);
+  // Announces cue-driven seeks to assistive tech. The native <audio> scrubber
+  // is shadow DOM we can't attach ARIA to, so clicking a transcript cue moves
+  // playback silently for a non-sighted user (WCAG 4.1.3). We write directly
+  // to this node (rather than via React state) so re-clicking the same cue —
+  // identical text — still triggers a fresh announcement instead of being
+  // deduped as an unchanged live region.
+  const announceRef = React.useRef<HTMLSpanElement>(null);
+  const announceSeek = React.useCallback((seconds: number) => {
+    const node = announceRef.current;
+    if (!node) {
+      return;
+    }
+    node.textContent = '';
+    requestAnimationFrame(() => {
+      if (announceRef.current) {
+        announceRef.current.textContent = `Jumped to ${formatTime(seconds)}`;
+      }
+    });
+  }, []);
   const [cues, setCues] = React.useState<VttCue[]>([]);
   const [text, setText] = React.useState<string>(legacyText);
   const [activeIndex, setActiveIndex] = React.useState<number>(-1);
@@ -292,6 +311,26 @@ export default function MDAudio(
               aria-label="Transcript"
               style={{ display: 'block' }}
             >
+              {hasCues && (
+                /* Visually hidden; announces the seek target for screen
+                   reader users when a cue button is activated. */
+                <span
+                  ref={announceRef}
+                  role="status"
+                  aria-live="polite"
+                  style={{
+                    position: 'absolute',
+                    width: 1,
+                    height: 1,
+                    margin: -1,
+                    padding: 0,
+                    overflow: 'hidden',
+                    clip: 'rect(0, 0, 0, 0)',
+                    whiteSpace: 'nowrap',
+                    border: 0,
+                  }}
+                />
+              )}
               {hasCues ? (
                 <ol style={{ listStyle: 'none', padding: 0, marginTop: 4 }}>
                   {cues.map((cue, index) => (
@@ -302,6 +341,7 @@ export default function MDAudio(
                         if (audioRef.current) {
                           audioRef.current.currentTime = cue.start;
                         }
+                        announceSeek(cue.start);
                       }}
                       style={{
                         display: 'flex',

--- a/packages/ui/src/lib/hooks/useLiveAnnouncer.ts
+++ b/packages/ui/src/lib/hooks/useLiveAnnouncer.ts
@@ -7,8 +7,8 @@ import { useCallback, useRef } from 'react';
  * triggers a fresh announcement — screen readers otherwise dedupe live-region
  * content that hasn't changed.
  */
-export const useLiveAnnouncer = <T extends HTMLElement = HTMLSpanElement>() => {
-  const ref = useRef<T>(null);
+export const useLiveAnnouncer = () => {
+  const ref = useRef<HTMLSpanElement>(null);
 
   const announce = useCallback((message: string) => {
     const node = ref.current;

--- a/packages/ui/src/lib/hooks/useLiveAnnouncer.ts
+++ b/packages/ui/src/lib/hooks/useLiveAnnouncer.ts
@@ -1,0 +1,27 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * Drives an ARIA live region (paired with `LiveStatusRegion`) for announcing
+ * text to screen readers. Writes directly to the DOM node rather than through
+ * React state so that announcing the same message twice in a row still
+ * triggers a fresh announcement — screen readers otherwise dedupe live-region
+ * content that hasn't changed.
+ */
+export const useLiveAnnouncer = <T extends HTMLElement = HTMLSpanElement>() => {
+  const ref = useRef<T>(null);
+
+  const announce = useCallback((message: string) => {
+    const node = ref.current;
+    if (!node) {
+      return;
+    }
+    node.textContent = '';
+    requestAnimationFrame(() => {
+      if (ref.current) {
+        ref.current.textContent = message;
+      }
+    });
+  }, []);
+
+  return { ref, announce };
+};


### PR DESCRIPTION
## Summary

Clicking a transcript cue button in the audio component's transcript panel now announces the new playback position ("Jumped to 1:23") to screen reader users. Previously the click silently moved the audio's playback position with no feedback — since the native `<audio>` scrubber is browser shadow DOM, assistive tech had no way to detect the change (WCAG 4.1.3).

### Changes

- Add a `useLiveAnnouncer` hook (`packages/ui/src/lib/hooks/useLiveAnnouncer.ts`) that drives an ARIA live region, writing directly to the DOM node so repeated announcements of the same message still get spoken (screen readers otherwise dedupe unchanged live-region text).
- Add a `LiveStatusRegion` component (`packages/ui/src/lib/accessibility/LiveStatusRegion.tsx`) — a visually-hidden `role="status"` element paired with the hook's ref — and export both from `@rapid-cmi5/ui`.
- Wire the hook/component into the cue-click handler in both `MDAudio.tsx` (the published player's audio renderer) and `AudioTranscript.tsx` (the editor's live preview, which shares the same transcript UI), replacing what was originally duplicated inline logic in each with a shared implementation.

### Ticket CCUI 3074
https://cybercents.atlassian.net/browse/CCUI-3074

## Test plan
- [ ] In the player, play an audio block with a VTT transcript, expand the transcript, and click a cue button with NVDA running — confirm it announces "Jumped to M:SS" and the audio seeks to that position.
- [ ] Click the same cue button twice in a row — confirm NVDA announces both times (not deduped as unchanged text).
- [ ] Repeat the same check in the editor's live preview (AudioEditor/AudioTranscript) to confirm parity.
- [ ] Confirm audio blocks without a timed VTT transcript (plain-text-only transcript) render unaffected — no live region, no console errors.
- [ ] Confirm the transcript toggle button, cue highlighting, and seeking behavior are all unchanged visually.
