### PR TITLE
Fix/cc UI 3075 codeblock readonly aria

### DIFF
--- a/packages/ui/src/lib/cmi5/mdx/plugins/code/CodeMirrorEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/code/CodeMirrorEditor.tsx
@@ -107,7 +107,15 @@ export const CodeMirrorEditor = ({
           // attribute. tabindex keeps the block reachable via Tab since
           // contenteditable="false" elements aren't natively focusable.
           EditorView.editable.of(false),
-          EditorView.contentAttributes.of({ tabindex: '0' }),
+          EditorView.contentAttributes.of({
+            // We don't want the tab to find this in order, it is technically content not an interactable item
+            tabindex: '-1',
+            // CodeMirror hardcodes role="textbox", which is what makes NVDA
+            // say "edit". aria-roledescription overrides the spoken role
+            // without touching the underlying role, turning the announcement
+            // into "code block, read only, multi line".
+            'aria-roledescription': 'code block',
+          }),
         );
       }
       if (language !== '' && autoLoadLanguageSupport) {


### PR DESCRIPTION
## Summary

In slide playback, code blocks were announced by NVDA as an editable field ("edit, has auto complete") even though they're static, read-only content — misleading screen reader users into thinking they could type into or autocomplete inside them. NVDA now announces them as "code block, read only," and they're excluded from the tab order since they're content, not an interactive control.

### Changes

- Swap CodeMirror's `basicSetup` for `minimalSetup` on read-only instances, dropping the bundled `autocompletion()` extension that caused the false "has auto complete" announcement, while `minimalSetup` still includes `syntaxHighlighting` so highlighting is unaffected.
- Set `EditorView.editable.of(false)` when read-only. Previously only `EditorState.readOnly` was set, which blocks edits but leaves `contenteditable="true"` in the DOM — this is why NVDA kept saying "edit" regardless.
- Add `EditorView.contentAttributes.of(...)` for read-only instances: `aria-roledescription: 'code block'` overrides the spoken role (CodeMirror hardcodes `role="textbox"`, which can't otherwise be changed), and `tabindex: '-1'` removes the block from the tab order.

### Ticket CCUI-3075
https://cybercents.atlassian.net/browse/CCUI-3075

## Test plan
- [ ] In the player, open a slide with a code block and confirm NVDA announces it as "code block, read only" instead of "edit, has auto complete"
- [ ] Confirm syntax highlighting still renders correctly on read-only code blocks
- [ ] Tab through a slide with a code block and confirm it's skipped (no longer a tab stop), and confirm the code content is still reachable/readable via NVDA's browse-mode navigation
- [ ] In the authoring editor (non-read-only), confirm code blocks are still editable with autocomplete and Tab-focusable as before — no regression to the authoring experience
