### PR TITLE
fix: fall back to title for image alt text and fix stray period in fu…

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
@@ -52,7 +52,7 @@ function LazyImage({
       id={id}
       className={className ?? undefined}
       alt={alt}
-      aria-label={isLinked ? undefined : `${alt}. Click to view full screen.`}
+      aria-label={isLinked ? undefined : `${alt} Click to view full screen.`}
       src={imgCache.read(url)}
       title={title}
       draggable="false"
@@ -192,7 +192,10 @@ export function ImageViewer({
               }}
             />
           ) : (
-            <Tooltip title="Click to view full screen" open={showFullscreenHint}>
+            <Tooltip
+              title="Click to view full screen"
+              open={showFullscreenHint}
+            >
               <div
                 id={`image-labels-${id}`}
                 ref={labelsRef}
@@ -215,7 +218,7 @@ export function ImageViewer({
             className={classNames(passedClassName)}
             src={imageSource}
             title={title ?? ''}
-            alt={alt ?? ''}
+            alt={alt || title || ''}
             isLinked={isLinked}
             onFullscreenHintVisibilityChange={setShowFullscreenHint}
             rest={rest}


### PR DESCRIPTION
## Summary

Images without their own alt text now fall back to the image's title for their accessible name, instead of being announced with no description at all. Also cleaned up the "click to view full screen" screen-reader label so it no longer begins with a stray extra period.

### Changes

- `ImageViewer.tsx`: `alt` passed to `LazyImage` now falls back to `title` when the image has no alt text (`alt || title || ''`), so the `<img alt>` attribute and its aria-label are never empty when a title is available.
- `ImageViewer.tsx`: removed the stray trailing period in the non-linked image's `aria-label` (`` `${alt} Click to view full screen.` ``), so it reads cleanly and matches the visible Tooltip copy ("Click to view full screen").

### Ticket number 3079
https://cybercents.atlassian.net/browse/CCUI-3079

## Test plan
- [ ] Insert an image with only a `title` set (no `alt`) and confirm a screen reader announces the title text instead of nothing.
- [ ] Insert an image with both `alt` and `title` set and confirm the `alt` text is still used (title is not overriding it).
- [ ] Hover/focus a non-linked image and confirm the tooltip and screen-reader announcement both read "Click to view full screen" with no double or trailing period.
- [ ] Confirm linked images (wrapped in `<a>`) are unaffected — no aria-label override, normal link navigation on click/enter.
