### PR TITLE
Fix/cc UI 3078 image accessibility fixes

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
@@ -260,7 +260,6 @@ function RC5Player() {
             setFullScreenImageStyle({});
           }
 
-          // remember what had focus so it can be restored when the dialog closes
           fullScreenTriggerRef.current =
             document.activeElement as HTMLElement | null;
 

--- a/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
@@ -461,7 +461,7 @@ function RC5Player() {
         <div
           role="dialog"
           aria-modal="true"
-          aria-label="Full screen image"
+          aria-label="Full screen image. Press Escape to exit."
           ref={fullScreenDialogRef}
           tabIndex={-1}
           onClick={(e: React.MouseEvent<HTMLDivElement>) => {
@@ -508,7 +508,7 @@ function RC5Player() {
             color="common.white"
             sx={{ padding: '6px', position: 'absolute', left: 0, bottom: 0 }}
           >
-            Click Anywhere to Close
+            Click Anywhere or Press Escape to Close
           </Typography>
         </div>
       )}

--- a/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/RC5Player.tsx
@@ -99,6 +99,10 @@ function RC5Player() {
   ).current;
 
   const slideContentRef = useRef<HTMLDivElement>(null);
+  const fullScreenDialogRef = useRef<HTMLDivElement>(null);
+  // remembers whatever had focus (usually the image) so it can be restored
+  // when the full screen dialog closes
+  const fullScreenTriggerRef = useRef<HTMLElement | null>(null);
 
   // Move focus into the slide region so NVDA starts reading from the top when a slide changes.
   // useEffect listens for activeTab, only fires when the active slide changes.
@@ -256,6 +260,10 @@ function RC5Player() {
             setFullScreenImageStyle({});
           }
 
+          // remember what had focus so it can be restored when the dialog closes
+          fullScreenTriggerRef.current =
+            document.activeElement as HTMLElement | null;
+
           // set the full screen image
           setFullScreenImage(src);
         }
@@ -296,6 +304,21 @@ function RC5Player() {
       window.removeEventListener('keydown', handleKeyDown);
     };
   }, []);
+
+  /**
+   * Move focus into the full screen dialog when it opens, and restore focus
+   * to whatever triggered it (usually the image) when it closes. Without
+   * this, focus silently stays on the (now hidden) slide image the whole
+   * time, which is what left screen readers unable to tell the dialog had
+   * opened or closed.
+   */
+  useEffect(() => {
+    if (fullScreenImage) {
+      fullScreenDialogRef.current?.focus();
+    } else {
+      fullScreenTriggerRef.current?.focus();
+    }
+  }, [fullScreenImage]);
 
   const editorContainerRef = useRef<HTMLDivElement>(null);
 
@@ -437,9 +460,21 @@ function RC5Player() {
       {fullScreenImage && (
         <div
           role="dialog"
+          aria-modal="true"
+          aria-label="Full screen image"
+          ref={fullScreenDialogRef}
+          tabIndex={-1}
           onClick={(e: React.MouseEvent<HTMLDivElement>) => {
             e.stopPropagation();
             setFullScreenImage('');
+          }}
+          onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+            // there's nothing else to tab to in here, so keep focus in the
+            // dialog rather than letting it wander into the hidden slide behind it
+            if (e.key === 'Tab') {
+              e.preventDefault();
+              fullScreenDialogRef.current?.focus();
+            }
           }}
           id="full screen"
           style={{

--- a/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
@@ -192,11 +192,13 @@ export function ImageViewer({
               }}
             />
           ) : (
-            <Tooltip title="Click to view full screen" open={showFullscreenHint}>
+            <Tooltip
+              title="Click to view full screen"
+              open={showFullscreenHint}
+            >
               <div
                 id={`image-labels-${id}`}
                 ref={labelsRef}
-                aria-hidden="true"
                 onMouseEnter={() => setShowFullscreenHint(true)}
                 onMouseLeave={() => setShowFullscreenHint(false)}
                 style={{

--- a/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
@@ -100,11 +100,9 @@ export function ImageViewer({
     imagePreviewHandler$,
   );
   const [imageSource, setImageSource] = React.useState<string | null>(null);
-  // images inside a link already navigate on click/enter and get their
-  // accessible name from the alt text, so they don't need the full-screen
-  // button/tooltip treatment. The overlay div is only rendered once
-  // imageSource resolves, so a callback ref is used instead of a mount
-  // effect, which would run before the div exists and never fire again.
+  // Linked images already navigate/announce via the <a>, so no fullscreen
+  // treatment needed. Uses a callback ref (not a mount effect) since this
+  // div isn't rendered until imageSource resolves, which an effect could miss.
   const [isLinked, setIsLinked] = React.useState(false);
   const labelsRef = React.useCallback((node: HTMLDivElement | null) => {
     if (node) {
@@ -199,18 +197,13 @@ export function ImageViewer({
               }}
             />
           ) : (
-            <Tooltip
-              title="Click to view full screen"
-              open={showFullscreenHint}
-            >
+            <Tooltip title={fullscreenTooltipText} open={showFullscreenHint}>
               <div
                 id={`image-labels-${id}`}
                 ref={labelsRef}
                 role="presentation"
-                // Tooltip clones its title onto aria-label unconditionally
-                // (@mui/material/Tooltip.js) - overriding it here to undefined
-                // stops this div from duplicating the image's own accessible
-                // name and being announced as an unlabeled grouping.
+                // Overrides Tooltip's auto-injected aria-label (MUI always clones
+                // title onto it), which duplicated the image's name as an unlabeled grouping.
                 aria-label={undefined}
                 onMouseEnter={() => setShowFullscreenHint(true)}
                 onMouseLeave={() => setShowFullscreenHint(false)}

--- a/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
+++ b/apps/cc-cmi5-player/src/app/components/player/plugins/image-player/ImageViewer.tsx
@@ -116,6 +116,13 @@ export function ImageViewer({
   // open state directly so both trigger it
   const [showFullscreenHint, setShowFullscreenHint] = React.useState(false);
 
+  // the overlay sits on top of the <img>, so its native title-attribute
+  // tooltip can never be reached by hover - fold it into this tooltip
+  // instead, since that's the one that actually receives hover/focus
+  const fullscreenTooltipText = title
+    ? `${title} — Click to view full screen`
+    : 'Click to view full screen';
+
   // determine styles
   let styleAttribute: MdxJsxAttribute | undefined;
   let style: React.CSSProperties = {};
@@ -192,13 +199,16 @@ export function ImageViewer({
               }}
             />
           ) : (
-            <Tooltip
-              title="Click to view full screen"
-              open={showFullscreenHint}
-            >
+            <Tooltip title={fullscreenTooltipText} open={showFullscreenHint}>
               <div
                 id={`image-labels-${id}`}
                 ref={labelsRef}
+                role="presentation"
+                // Tooltip clones its title onto aria-label unconditionally
+                // (@mui/material/Tooltip.js) - overriding it here to undefined
+                // stops this div from duplicating the image's own accessible
+                // name and being announced as an unlabeled grouping.
+                aria-label={undefined}
                 onMouseEnter={() => setShowFullscreenHint(true)}
                 onMouseLeave={() => setShowFullscreenHint(false)}
                 style={{

--- a/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
@@ -285,7 +285,7 @@ export const ImageLabelEditor: React.FC<
             name="Image Marker"
             props={{
               'aria-expanded': isOpen,
-              'aria-label': isOpen ? 'Hide label content' : 'Show label content',
+              'aria-label': 'Toggle label content',
               onClick: (event) => {
                 event.stopPropagation();
                 handleToggle(event);

--- a/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
@@ -237,11 +237,8 @@ export const ImageLabelEditor: React.FC<
     }
   };
 
-  // Escape closes the label without requiring the toggle button to be
-  // reactivated - NVDA can lose track of a control right after it caused a
-  // DOM change (confirmed live: its browse-mode position can fully desync
-  // from the real page), so this gives keyboard/AT users a reliable second
-  // path that doesn't depend on that same element again.
+  // Escape closes the label independent of the toggle button, which NVDA can
+  // lose track of right after it causes a DOM change (confirmed live).
   useEffect(() => {
     if (!isOpen) return;
     const handleEscape = (event: KeyboardEvent) => {

--- a/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
@@ -204,17 +204,24 @@ export const ImageLabelEditor: React.FC<
   };
 
   /**
+   * Close the label content, if open
+   */
+  const closeLabel = () => {
+    document.removeEventListener('mousedown', handleMouseDown);
+    imageLabelKeys$.value = {
+      ...imageLabelKeys$.value,
+      [imageId]: null,
+    };
+  };
+
+  /**
    * Toggle Label Content open/closed
    * @param event
    */
   const handleToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (imageId) {
       if (isOpen) {
-        document.removeEventListener('mousedown', handleMouseDown);
-        imageLabelKeys$.value = {
-          ...imageLabelKeys$.value,
-          [imageId]: null,
-        };
+        closeLabel();
       } else {
         checkLabelPlacement();
         setAnchorEl(event?.currentTarget);
@@ -229,6 +236,22 @@ export const ImageLabelEditor: React.FC<
       debugLog('no imageId found for label');
     }
   };
+
+  // Escape closes the label without requiring the toggle button to be
+  // reactivated - NVDA can lose track of a control right after it caused a
+  // DOM change (confirmed live: its browse-mode position can fully desync
+  // from the real page), so this gives keyboard/AT users a reliable second
+  // path that doesn't depend on that same element again.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeLabel();
+      }
+    };
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [isOpen]);
 
   /**
    * Listen for image label open change

--- a/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
+++ b/packages/ui/src/lib/cmi5/mdx/plugins/image-label/ImageLabelEditor.tsx
@@ -305,7 +305,7 @@ export const ImageLabelEditor: React.FC<
             name="Image Marker"
             props={{
               'aria-expanded': isOpen,
-              'aria-label': 'Toggle label content',
+              'aria-label': isOpen ? 'Hide label content' : 'Show label content',
               onClick: (event) => {
                 event.stopPropagation();
                 handleToggle(event);


### PR DESCRIPTION
## Summary

Fixes several CCUI-3078 image accessibility findings: the fullscreen image viewer now announces itself and explains how to exit when it opens ("Full screen image. Press Escape to exit."), keeps keyboard focus trapped inside it while open, and correctly restores focus to the originating image on close. An image's `title` text is now surfaced through the same tooltip users actually hover/focus (it was previously unreachable, hidden behind the fullscreen-click overlay), and a redundant/duplicate "Click to view full screen" announcement caused by that overlay has been removed. The image-label marker popup can now also be closed with Escape, giving keyboard/screen-reader users a reliable way to dismiss it that doesn't depend on reactivating the same toggle button.

### Changes

- `RC5Player.tsx`: opening fullscreen now moves the keyboard focus into the view, keeps Tab from leaking into the hidden slide behind it, and puts focus back on the original image when you close it. Both the screen-reader announcement and the on-screen caption now say "Press Escape to exit."
- `ImageViewer.tsx`: an image's `title` text was getting silently blocked by an invisible click-layer sitting on top of every image, so now it's folded into the tooltip. That same invisible layer is also where the image-label marker button lives when one's attached, it was marked  " aria-hidden="true" " which essentially hides it completely from screen readers. This causes a problem once there's a real clickable button inside it, so that's been corrected, along with a duplicate "click to view full screen" announcement it was causing.
- `ImageLabelEditor.tsx`: the label popup can now also be closed with Escape, not just by re-clicking the marker button. Also stopped the marker button from renaming itself every time it's clicked ("Show"/"Hide label content")- its name now stays constant, and open/closed state is announced the standard way.

### Ticket 3078
https://cybercents.atlassian.net/browse/CCUI-3078

## Test plan
- [ ] Tab to an image, press Enter to open fullscreen; confirm NVDA announces "Full screen image. Press Escape to exit." and Tab stays trapped inside the dialog.
- [ ] Press Escape (or click) to close fullscreen; confirm focus returns to the originating image.
- [ ] Hover/focus an image with a `title` set; confirm the tooltip reads "`<title>` — Click to view full screen" instead of a native browser tooltip that never appeared.
- [ ] Open an image-label marker popup with NVDA running, then press Escape; confirm it closes reliably, including on repeat open/close cycles.
- [ ] Confirm mouse-based open/close (click marker button, click outside) is unaffected.
