### PR TITLE
fix(cc-cmi5-player): match Build Info button aria-label to its visibl…

### DIFF
--- a/apps/cc-cmi5-player/src/app/components/Menu/BuildInfoButton.tsx
+++ b/apps/cc-cmi5-player/src/app/components/Menu/BuildInfoButton.tsx
@@ -47,7 +47,7 @@ export default function BuildInfoButton({ color }: { color?: string }) {
       >
         <IconButton
           sx={{ width: '32px', height: '32px' }}
-          aria-label="Build Information"
+          aria-label="About RapidCMI5"
           color="primary"
           onClick={(e) => setAnchor(e.currentTarget)}
         >


### PR DESCRIPTION
## Summary

The "About RapidCMI5" build-info button in the player toolbar now announces itself as "About RapidCMI5" to screen readers and voice-control users, matching the tooltip sighted users already see on hover. Previously its accessible name was "Build Information," a different string than its visible label — voice-control users saying "click About RapidCMI5" couldn't activate the button (WCAG 2.5.3 Label in Name).

### Changes

- Updated `aria-label` on the build-info `IconButton` in `BuildInfoButton.tsx` from `"Build Information"` to `"About RapidCMI5"`, matching the existing `Tooltip title`.

### Ticket: CCUI-3137
https://cybercents.atlassian.net/browse/CCUI-3137

## Test plan
- [ ] Hover the build-info (RapidCMI5 logo) icon button in the player toolbar and confirm the tooltip still reads "About RapidCMI5"
- [ ] Inspect the button in the browser's Accessibility pane (or screen reader) and confirm the accessible name is now "About RapidCMI5", not "Build Information"
- [ ] Click the button and confirm the build-info popover (version, branch, remote, build time) still opens and closes normally — behavior is unchanged, only the label
