### PR TITLE
docs(moodle-e2e): add guided run script and rewrite the runbook

### DIFF
--- a/apps/cc-cmi5-moodle-e2e/README.md
+++ b/apps/cc-cmi5-moodle-e2e/README.md
@@ -1,257 +1,394 @@
 # Moodle-Launched Playwright E2E Tests
 
-## 1. Goal — Create an e2e framework that allows verification of core functionality on predefined cmi5 course(s) usage via Moodle.
+These tests drive the **real** CMI5 player the way a student does: log into
+Moodle as a bot account, click an activity's **Launch** button, and assert
+against the player running inside Moodle's `launch.php` iframe — against a live
+LRS, and (for the scenario lane) real deployed VMs.
 
-This will allow testing scenarios, LRS, resumes etc. more accurately than trying strictly frontend or local-only tests.
+**New here? Read §1, copy the env block, run the command. That's it.**
+Everything from §4 down is background you only need when something breaks.
 
-| Use Case |
-| --- |
-| Export e2e tests from cmi5 player |
-| Upload course zip to e2e bot account |
-| Setup `.env.local` according to docs below then launch tests in Playwright |
+---
+
+## 1. Quick start
+
+### First: which loop are you in?
+
+There are two, and they are not the same. Picking the wrong one gives you a
+**false pass** — a green suite that never saw your change.
+
+| | **A. Verifying the suite** | **B. Testing a player/course change** |
+| --- | --- | --- |
+| You are… | checking the tests still work, or debugging a spec | changing the player or the course content |
+| Build the player | not needed | **required** |
+| Export + upload to Moodle | not needed | **required** |
+| Steps below | 1 → 2 → 3 | 1 → 2 → **§5** → 3 |
+| One-command version | `npm run e2e` | `npm run e2e -- --all` |
+
+> ⚠️ **Nothing in the test run picks up local player changes.** There is no
+> `webServer` in the Playwright config — the tests log into remote Moodle and
+> assert inside its `launch.php` iframe. The player running there is whatever
+> was last uploaded. So if you edited the player and skipped §5, the suite runs
+> against the **old** player and passes green. That is the most expensive
+> mistake available here, because nothing fails to warn you.
+>
+> (`project.json` lists `cc-cmi5-player` under `implicitDependencies`, which
+> looks like it would handle this for you. It does not — the `e2e` target has no
+> `dependsOn`, so Nx never builds or uploads anything for a test run.)
+
+### Step 0 — Fresh clone only
 
 ```bash
+npm install
+```
+
+### Step 1 — Get the credentials
+
+Ask a teammate for the `.env.local` values (bot password + WS tokens). They are
+secrets and are **never** committed.
+
+### Step 2 — Create `.env.local` at the **repo root**
+
+Not in this app folder — the repo root (`rapidcmi5/.env.local`). It is
+gitignored and takes precedence over `.env`.
+
+```bash
+# --- Required for every run ---------------------------------------------
+MOODLE_BASE_URL=https://moodle5.develop-cp.rangeos.engineering
+MOODLE_ACTIVITY_ID=784          # the `id` in mod/cmi5/view.php?id=<id>
 MOODLE_BOT_USER=e2e-rc5-bot
-MOODLE_BOT_PASS=e2e-RC5-@-botman-928
-MOODLE_ACTIVITY_ID=779
+MOODLE_BOT_PASS=<ask a teammate>
+
+# --- Required so each run starts from a clean slate ----------------------
+MOODLE_BOT_USER_ID=30           # the bot's NUMERIC id (profile URL ?id=<n>)
+MOODLE_RESET_WS_TOKEN=<ask a teammate>
+
+# --- Only needed for the @scenario lane (§3) -----------------------------
+NX_PUBLIC_DEVOPS_API_URL=https://rangeos-api.develop-cp.rangeos.engineering
+KEYCLOAK_BOT_USER=<ask a teammate>
+KEYCLOAK_BOT_PASS=<ask a teammate>
+
+# --- Only needed to re-upload the course zip (§5) ------------------------
+MOODLE_WS_TOKEN=<ask a teammate>
+MOODLE_COURSE_ID=75             # course CONTAINER id, not the activity id
 ```
 
-We DO have upsert support now:
+### Step 3 — Run it
 
 ```bash
-npm run upload:moodle -- --zip "C:/path/to/e2e-tests.zip"
+npm run e2e
 ```
 
-## 2. Project layout
+This walks you through the whole loop, asking before each step so you can skip
+the expensive ones:
+
+```text
+1/3  Build the player?              [y/N]   ← default NO (slow; only if you changed the player)
+2/3  Upload the course to Moodle?   [y/N]   ← default NO (defaults to YES if you built)
+3/3  Run the tests?                 [Y/n]   ← default YES
+```
+
+Pressing Enter three times is loop A — straight to the tests. Answering yes to
+the first two is loop B, and the script keeps the ordering honest: it pauses for
+the editor export, auto-finds the newest zip in Downloads (showing its age, so a
+stale one is obvious), and warns loudly if you build without uploading.
+
+**On progress clearing.** The upsert preserves the learner's prior progress
+(§4), so it has to be cleared or scenario AUs resume as already-"Satisfied".
+That clear happens in two places, deliberately:
+
+- **Right after the upload**, in this script, against the cmid that was just
+  deployed. This is what makes an upload-only run (`--no-test`) leave Moodle in
+  a clean state.
+- **Again in `globalSetup`** when the suite starts (§4).
+
+The script also compares the deployed cmid against `MOODLE_ACTIVITY_ID` and
+warns if they've diverged — an upsert normally preserves the id, but a new
+project or a changed `courseId` IRI produces a new one, which would leave
+`.env.local` pointing at the wrong activity.
+
+Non-interactive flags, for when you already know what you want:
+
+```bash
+npm run e2e -- --all             # build + upload + test, no prompts
+npm run e2e -- --upload          # upload + test (course content changed)
+npm run e2e -- --yes             # accept all defaults (= just run the tests)
+npm run e2e -- --config scenario # any e2e configuration (default chromium)
+npm run e2e -- --zip <path>      # explicit zip instead of auto-detect
+npm run e2e -- --no-test         # build/upload only
+```
+
+Or drive Nx directly if you prefer:
+
+```bash
+npx nx e2e cc-cmi5-moodle-e2e --configuration=chromium
+```
+
+That is the whole loop. ~17 tests, ~3 minutes, no infra beyond Moodle itself.
+A browser window opens locally so you can watch the real launch flow (headless
+in CI).
+
+**Expected result:** `17 passed`. If you get `Missing required env var …`, go
+back to Step 2. For anything else, see §6 Troubleshooting.
+
+> **If you changed the player or the course, stop.** A green run here proves
+> nothing until you have done §5 — you just tested the previously-uploaded
+> player. Go to §5, then come back and re-run this.
+
+### The commands you'll actually use
+
+| I want to… | Command |
+| --- | --- |
+| **The guided loop** (asks build / upload / test) | `npm run e2e` |
+| **The whole loop B, no prompts** | `npm run e2e -- --all` |
+| **Run the normal suite** (media + components + quiz) | `npx nx e2e cc-cmi5-moodle-e2e --configuration=chromium` |
+| Watch it run / debug it | `npx nx e2e cc-cmi5-moodle-e2e --configuration=chromium-debug` |
+| Pick individual tests, time-travel | `npx nx e2e cc-cmi5-moodle-e2e --configuration=chromium-ui` |
+| Run just the content tests | `npx nx e2e cc-cmi5-moodle-e2e --configuration=content` |
+| Run just the quiz tests | `npx nx e2e cc-cmi5-moodle-e2e --configuration=quizzes` |
+| Run the slow VM/scenario tests (§3) | `npx nx e2e cc-cmi5-moodle-e2e --configuration=scenario` |
+| Watch the scenario tests deploy VMs | `npx nx e2e cc-cmi5-moodle-e2e --configuration=scenario-debug` |
+| See the report from the last run | `npx nx e2e-report cc-cmi5-moodle-e2e` |
+
+You can also run and debug individual tests straight from the **Playwright Test
+extension** in VS Code — that's the day-to-day loop for most of us.
+
+> ⚠️ The VS Code extension's side panel **skips `globalSetup`**, so the
+> registration reset (§4) does not run there. Tests that depend on a clean
+> "Not started" state — the scenario lane especially — can behave differently
+> than a CLI run. Use the CLI when that matters.
+
+---
+
+## 2. What gets tested
+
+The e2e course is split into functionality-grouped **AUs** (lessons) — each one
+a launchable row in Moodle's Assignable Units table. A spec picks its AU with
+`test.use({ auName: '…' })`.
+
+| AU (`auName`) | Spec | Tag | What it verifies |
+| --- | --- | --- | --- |
+| `Media:Basic` | `media-basic.spec.ts` | `@content` | Image `<img>`, Video `<video>`, Audio `<audio>` slides render |
+| `Components:Basic` | `components-basic.spec.ts` | `@content` | tabs, accordion, layout grid, statements, quote admonition, table — render + expected content |
+| `Quiz:Basic` | `quiz-basic.spec.ts` | `@quizzes` | quiz renders; submit → 100% / 0% scored via the real LRS; Review Answers hint |
+| `Scenario:Individual` | `scenario-individual.spec.ts` | `@scenario` | auto-deploys a VM on launch → reaches Ready → HYPERVISOR console connects (Guacamole) |
+| `Scenario:Class` | `scenario-class.spec.ts` | `@scenario` | deploy a class scenario via API → "Enter Class" prompt → console connects |
+| `Scenario:Team` | `scenario-team.spec.ts` | `@scenario` | deploy a shared team instance via API + Keycloak SSO → console connects |
+
+Individual and Class scenarios can't live in the same cmi5 lesson, which is the
+main reason the course is split this way.
+
+---
+
+## 3. Two lanes: content vs. scenario
+
+**Content lane** (`@content`, `@quizzes`) — Media / Components / Quiz. Fast, no
+infrastructure beyond Moodle. **This is the default run** and what you should
+use to check "is the player still working."
+
+**`@scenario` lane** — Individual / Class / Team. Slow (minutes), deploys real
+VMs through RangeOS, and **can fail for reasons that have nothing to do with
+your change** (range backend down, capacity, Keycloak). Deliberately excluded
+from the default run; invoke it on demand.
+
+> **Why each scenario spec is one long test.** A scenario AU auto-completes and
+> caches a cmi5 session on launch. Re-launching that same AU later resumes the
+> satisfied registration and never re-deploys — it just hangs at "never Ready."
+> So each scenario spec does the whole chain in a single test (render → deploy →
+> Ready → connect) rather than several tests that each re-launch.
+
+---
+
+## 4. How it works
+
+### Project layout
 
 ```text
 apps/cc-cmi5-moodle-e2e/
-  playwright.config.ts        # No webServer — Moodle is a remote, running site
-  project.json                # Nx targets + run configurations (see §7)
+  playwright.config.ts          # No webServer — Moodle is a remote, running site
+  project.json                  # Nx run configurations (the table in §1)
   scripts/
-    upload-zip-to-moodle.js   # Standalone course-zip upserter (see §6)
+    e2e-run.js                  # Guided build → upload → test loop (npm run e2e)
+    upload-zip-to-moodle.js     # Course-zip upserter (see §5)
   src/
-    e2e/                      # The specs
-      media-basic.spec.ts        # Image / Video / Audio slides
-      components-basic.spec.ts   # tabs / accordion / grid / statements / quote / table
-      quiz-basic.spec.ts         # quiz render + scoring (real LRS)
-      scenario.spec.ts           # Scenario:Individual (auto-deploy, full chain)
-      scenario-class.spec.ts     # Scenario:Class (deploy via API + class prompt)
-      scenario-team.spec.ts      # Scenario:Team (shared SSO instance)
+    global-setup.ts             # Runs ONCE per run: resets the bot's progress
+    e2e/                        # The specs
+      media-basic.spec.ts
+      components-basic.spec.ts
+      quiz-basic.spec.ts
+      scenario-individual.spec.ts
+      scenario-class.spec.ts
+      scenario-team.spec.ts
     fixtures/
-      moodle-course-fixture.ts  # The `player` fixture: login → launch AU → hand back the iframe scope
+      moodle-course-fixture.ts  # The `player` fixture: login → launch AU → iframe scope
     moodle/
       env.ts                    # Validated env access (all config in one place)
       moodleSession.ts          # login(), gotoActivity(), launchAu()
     lms/                        # RangeOS/Keycloak helpers for the scenario lane
-      deployClassScenario.ts    # Deploy class/team scenarios via the devops API + wait-for-ready
-      keycloakToken.ts          # Mint the rangeos-api JWT via Keycloak password grant
-      keycloakLogin.ts          # Establish a Keycloak browser SSO session (team scenarios)
-      scenarioReady.ts          # waitForScenarioReady() — polls the player's status
+      resetRegistration.ts      # Clears the bot's cmi5 progress via Moodle WS
+      deployClassScenario.ts    # Deploy class/team scenarios + wait-for-ready
+      keycloakToken.ts          # Mint the rangeos-api JWT (password grant)
+      keycloakLogin.ts          # Keycloak browser SSO session (team scenarios)
+      scenarioReady.ts          # waitForScenarioReady() — polls player status
 ```
 
 ### How a spec works
 
-A spec declares which AU (lesson) it launches via the `auName` option, then
-queries the player through the `player` fixture:
-
 ```ts
 import { test, expect } from '../fixtures/moodle-course-fixture';
 
-test.use({ auName: 'Media:Basic' });
+test.describe('test basic media @content', () => {
+  test.use({ auName: 'Media:Basic' });
 
-test('Image slide renders an <img>', async ({ player }) => {
-  await player.getByTestId('player-slide-tab-0').click();
-  await expect(player.getByTestId('player-slide-content').locator('img')).toBeVisible();
+  test('Image slide renders an <img>', async ({ player }) => {
+    await player.getByTestId('player-slide-tab-0').click();
+    await expect(
+      player.getByTestId('player-slide-content').locator('img'),
+    ).toBeVisible();
+  });
 });
 ```
 
-`player` is a Playwright `FrameLocator` into Moodle's `launch.php` iframe.
-All player test-ids (`player-slide-*`, `directive-*`, `scenario-*`, …) resolve
-inside it. The fixture does the whole real flow first — bot login → open the cmi5
-activity → click the AU's Launch link → resolve the embedded player — so the
-test body starts already on the launched player.
+`player` is a Playwright `FrameLocator` into Moodle's `launch.php` iframe. All
+player test-ids (`player-slide-*`, `directive-*`, `scenario-*`, …) resolve
+inside it. The fixture performs the whole real flow first — bot login → open the
+cmi5 activity → click the AU's **Launch** link → resolve the embedded player —
+so your test body starts already on a launched player.
 
-## 3. Initial tests covered
+### The clean-slate reset
 
-The e2e course is split into functionality-grouped AUs (each a launchable row
-in Moodle's Assignable Units table). Individual and Class scenarios can't share a
-cmi5 lesson, which is the main reason for the split.
+`global-setup.ts` runs **once** before the suite and clears the bot's cmi5
+registration (`mod_cmi5_reset_registration_state`), so the run starts from "Not
+started."
 
-| AU (`auName`) | Spec | What it verifies |
-| --- | --- | --- |
-| `Media:Basic` | `media-basic.spec.ts` | Image `<img>`, Video `<video>`, Audio `<audio>` slides render |
-| `Components:Basic` | `components-basic.spec.ts` | tabs, accordion, layout grid, statements, quote admonition, table — render + fixture content |
-| `Quiz:Basic` | `quiz-basic.spec.ts` | quiz directive renders; submit → score 100% / 0% via real LRS; Review Answers hint |
-| `Scenario:Individual` | `scenario.spec.ts` | auto-deploys a VM on launch → reaches Ready → HYPERVISOR console connects (Guacamole) |
-| `Scenario:Class` | `scenario-class.spec.ts` | deploy a class scenario via API → "Enter Class" prompt → console connects |
-| `Scenario:Team` | `scenario-team.spec.ts` | deploy a shared team instance via API + Keycloak SSO → console connects |
+This matters because the course upsert preserves prior progress: without the
+reset, a scenario AU resumes as already-"Satisfied" and the player skips
+straight to the End Slide instead of deploying. A registration is
+per-activity + user and the reset clears `au_status` for **all** AUs under it,
+so one reset covers the whole run.
 
-**Two lanes:**
+It is best-effort — it warns and continues if the bot user id can't be resolved,
+and treats "never launched yet" as already-clean. You'll see this line on a
+successful run:
 
-- **Content lane** (Media / Components / Quiz) — fast, no infra. The default run.
-- **`@scenario` lane** (Individual / Class / Team) — slow, depends on RangeOS
-  deploying real VMs (minutes, can be down). Kept out of the default run and
-  invoked on demand (see §7).
+```
+[resetRegistration] reset cmid=784 userid=30 → clean slate
+```
 
-Scenario tests do the whole chain in one launch. Each scenario AU
-auto-completes and caches a cmi5 session on launch; re-launching the same
-scenario AU in a later test resumes that satisfied registration and never
-re-deploys (it gets stuck "never Ready"). So each scenario spec is a single
-comprehensive test — render → deploy → Ready → connect — rather than several
-tests that each re-launch. (This can and likely will change when we test resuming etc.)
+### Execution notes
 
-## 4. How the e2e course is created / updated
+- `workers: 1` — the tests share one remote Moodle course, so they're serialized.
+- `retries: 2` — the live player intermittently crashes on launch (a pre-existing
+  `"A is not a function"` in `useCMI5Session`'s console-creds path, present on
+  main and unrelated to these tests). That blanks the iframe. Retrying
+  re-launches rather than red-flagging the suite.
 
-The course content is authored in the RapidCMI5 editor, and broken down into
-lessons to test different functionality. The e2e repo is at
+---
+
+## 5. Testing a player or course change (loop B)
+
+**This is the loop you use when you are developing**, not an occasional chore.
+Any change to the player or to the course content has to be built, exported and
+uploaded before the tests can see it — see the warning in §1.
+
+Use this when you changed the player, changed the course (a slide, a directive,
+a new AU), or need a test-id the bundled player doesn't have yet.
+
+The course is authored in the RapidCMI5 editor. The e2e course repo is
 <https://gitlab.global.rangeos.engineering/metova-cmi5-builder/team-2/e2e-tests.git>
-and can be imported into the editor. (Anyone with team-2 access should be already set up.)
+and can be imported into the editor (anyone with team-2 access is already set
+up). Scenarios follow the naming convention `e2e-<typeoftest>-<testdetails>`
+(e.g. `e2e-basic-individual`).
 
-A scenario for each test type should be created with each scenario having a
-consistent naming convention i.e. `e2e-<typeoftest>-<testdetails>`.
+### ⚠️ The zip must bundle a PRODUCTION player build
 
-### Critical: the zip must bundle a PRODUCTION player build
-
-The player bundled into the course zip is what runs inside Moodle. Two
-requirements:
-
-1. **It must be a production build.** A dev build 404s its `vendor.js` and the
-   player iframe renders blank.
-2. **It must carry the test-id contract the specs query** (`player-slide-*`,
+1. **Production, not dev.** A dev build 404s its `vendor.js` and the player
+   iframe renders blank.
+2. **It must carry the test-id contract** the specs query (`player-slide-*`,
    `directive-*`, `scenario-*`, `team-scenario-*`, `data-connected`, …). These
-   live in the `cc-cmi5-player` source; if the bundled player predates a test-id,
+   live in `cc-cmi5-player` source — if the bundled player predates a test-id,
    the matching spec can't find it.
 
-**Authoring / refresh flow:**
+### The loop
 
-1. Build the production player and stage it for the editor:
-   ```bash
-   npm run build:player-for-editor
-   ```
-   (→ `scripts/buildCmi5PlayerForEditor.sh`: prod build, hashed chunks,
-   vendorChunk off, zipped, copied into the editor's assets)
-2. In the editor UI, (re-)export the e2e course → `e2e-tests.zip`
-   (this embeds the freshly-built player).
-3. Upload the zip to Moodle (see §5).
-
-## 5. Getting the course into Moodle — today vs. the planned upsert
-
-### Today (manual)
-
-1. In Moodle: delete the existing cmi5 activity, create a new one, upload the zip.
-2. The new activity gets a NEW id (the `id` in `mod/cmi5/view.php?id=<id>`).
-3. Update `MOODLE_ACTIVITY_ID` in `.env.local` to that new id.
-
-The pain: the activity id churns on every re-upload, so `.env.local` must be
-updated each time, and a stale/forgotten id silently points the suite at the
-wrong activity (or even an unrelated course).
-
-### Planned — one-click / scripted upsert (update-in-place)
-
-The goal is to upsert the existing activity instead of delete-and-recreate, so
-the activity id stays stable and `MOODLE_ACTIVITY_ID` never has to change.
-
-This is being built two ways:
-
-- A button/action in the editor — export + upload-in-place in one step.
-- A standalone script (already in the repo, pending full verification against
-  the Moodle plugin).
-
-## 6. Environment values (`.env.local`)
-
-Config is read in one place — `src/moodle/env.ts` — which validates required vars
-and supplies sensible defaults for the rest. Secrets live in a gitignored
-`.env.local` at the repo root (loaded with precedence over `.env`). Never
-commit credentials. See a teammate for passwords and tokens.
+Four steps. Step 2 is a manual step in the editor UI — there is currently no
+script that goes straight from a player build to a course zip, because the zip
+has to bundle the player *and* the course content together.
 
 ```bash
-# ── Moodle course upsert (npm run upload:moodle) ───────────────────────────
-# Upserts a prebuilt cmi5 zip into Moodle via the local_rapidcmi5 plugin's
-# deploy_package WS, updating the activity IN PLACE (preserving its cmid /
-# mod/cmi5/view.php?id=) so the activity id stops churning on every re-upload.
-# Keyed on the package's courseId IRI (auto-read from the zip's cmi5.xml).
-# Usage (only --zip changes per run):
-#   npm run upload:moodle -- --zip "C:/path/to/e2e-tests.zip"
-#
-# WS token on the "RapidCMI5 Integration" service (local_rapidcmi5) with the
-# local/rapidcmi5:deploy capability — the existing gitlab-rapidcmi5 admin token
-# works. See C:\code\bylight\moodle-mod_rapidcmi5 / its README.
-# MOODLE_WS_TOKEN=
-# Moodle COURSE CONTAINER id — the `id` in /course/view.php?id=75. This is the
-# course the activity is deployed into; NOT the activity/module id.
-# MOODLE_COURSE_ID=75
-# Course section id (default 0).
-# MOODLE_SECTION_ID=0
-# Moodle base URL (shared with the e2e suite; default develop-cp).
-# MOODLE_BASE_URL=https://moodle5.develop-cp.rangeos.engineering
-# Optional: project display name in Moodle (default "E2E Tests").
-# MOODLE_ACTIVITY_NAME=E2E Tests
+# 1. Build the production player and stage it into the editor's assets
+npm run build:player-for-editor
 
-# ── e2e progress reset (clean slate per test run) ──────────────────────────
-# The e2e fixture resets the bot's cmi5 registration BEFORE each launch so runs
-# start "Not started" (the upsert preserves the cmid AND prior progress, so
-# otherwise scenario AUs resume as already-Satisfied and skip to the End Slide).
-# Uses mod_cmi5_reset_registration_state. The built-in "RapidCMI5 Integration"
-# service can't be edited in the Moodle UI, so create a CUSTOM external service,
-# add mod_cmi5_reset_registration_state (+ core_user_get_users_by_field for the
-# userid auto-lookup), and mint a token on it → MOODLE_RESET_WS_TOKEN. Falls back
-# to MOODLE_WS_TOKEN if both functions ever live on one service.
-# MOODLE_RESET_WS_TOKEN=
-# The bot's NUMERIC Moodle user id (from the user's profile URL: ...?id=<n>).
-# If unset, the fixture tries core_user_get_users_by_field, else skips the reset.
-# MOODLE_BOT_USER_ID=
-```
+# 2. In the editor UI: (re-)export the e2e course -> e2e-tests.zip
+#    This is what bundles the player you just built WITH the course content.
+#    Skipping this means step 3 uploads a zip with the OLD player in it.
 
-### Which vars matter for which run
+# 3. Upsert the zip into Moodle (updates the activity IN PLACE)
+npm run upload:moodle -- --zip "C:/path/to/e2e-tests.zip"
 
-| Run | Needs |
-| --- | --- |
-| Content lane (Media / Components / Quiz) | `MOODLE_BASE_URL`, `MOODLE_ACTIVITY_ID`, `MOODLE_BOT_USER`/`PASS` |
-| `@scenario` Individual | + nothing extra (auto-deploys via the player itself) |
-| `@scenario` Class / Team | + `NX_PUBLIC_DEVOPS_API_URL` and either `RANGEOS_API_JWT` or `KEYCLOAK_BOT_USER`/`PASS` (mint). Team also uses the Keycloak SSO session. |
-| Course upload script (§5) | `MOODLE_WS_TOKEN`, `MOODLE_COURSE_ID` |
-
-## 7. Running the tests
-
-Defined as Nx run configurations in `project.json` (target `e2e`). The suite runs
-headed locally (to watch the real launch flow) and headless in CI;
-`workers: 1` (serialized) because the tests share one remote Moodle course.
-
-### From the command line
-
-```bash
-# Default content lane (excludes @scenario)
+# 4. Now run the tests (§1 step 3)
 npx nx e2e cc-cmi5-moodle-e2e --configuration=chromium
-
-# Headed, list reporter, single worker — good for watching/debugging
-npx nx e2e cc-cmi5-moodle-e2e --configuration=chromium-debug
-
-# Playwright UI mode (time-travel, pick individual tests)
-npx nx e2e cc-cmi5-moodle-e2e --configuration=chromium-ui
-
-# Smoke only (just the @launch-tagged check)
-npx nx e2e cc-cmi5-moodle-e2e --configuration=launch
-
-# The slow, infra-dependent @scenario lane (Individual / Class / Team)
-npx nx e2e cc-cmi5-moodle-e2e --configuration=scenario
-
-# @scenario headed + list reporter (watch the VM deploy + console connect)
-npx nx e2e cc-cmi5-moodle-e2e --configuration=scenario-debug
-
-# Open the last HTML report
-npx nx e2e-report cc-cmi5-moodle-e2e
 ```
 
-> I usually just test manually via the Playwright Test extension.
+`build:player-for-editor` runs `nx build cc-cmi5-player`, zips the output, and
+copies it to `apps/rapid-cmi5-electron-frontend/src/assets/cc-cmi5-player.zip`.
+It stages the player for the editor — it does **not** produce a course zip, which
+is why step 2 can't be skipped.
 
-## 8. Todo / Upcoming Additions
+### Or let the script drive it
+
+`npm run e2e -- --all` runs exactly the four steps above: builds, pauses for the
+editor export, finds the zip, uploads, and runs the suite — see §1 step 3.
+`scripts/e2e-run.js` is a thin wrapper over the same npm scripts, so anything it
+does you can also do by hand.
+
+Step 3 upserts via the `local_rapidcmi5` plugin's `deploy_package` WS, keyed on
+the package's `courseId` IRI (auto-read from the zip's `cmi5.xml`). Because it
+updates in place, the **cmid stays stable** — `MOODLE_ACTIVITY_ID` no longer
+churns on every upload the way it did under the old delete-and-recreate flow.
+
+Optional flags: `--version <str>` (defaults to a build timestamp),
+`--project-id <iri>` (overrides the courseId read from `cmi5.xml`).
+
+Needs `MOODLE_WS_TOKEN` (on the "RapidCMI5 Integration" service, with the
+`local/rapidcmi5:deploy` capability) and `MOODLE_COURSE_ID`. See
+`C:\code\bylight\moodle-mod_rapidcmi5` and its README.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `Missing required env var MOODLE_BOT_USER` (or similar) | `.env.local` is missing, or it's in this app folder instead of the **repo root**. |
+| Every test fails at login | Bot password rotated, or Moodle is down. Open `MOODLE_BASE_URL` in a browser and log in by hand. |
+| Player iframe is blank | The course zip bundles a **dev** player build (404s `vendor.js`). Re-run the §5 refresh flow. |
+| **Tests pass but your change isn't there** | You skipped §5. The suite ran against the previously-uploaded player. Build → export → upload, then re-run. |
+| A spec can't find a test-id | The bundled player predates that test-id. Rebuild + re-upload the course (§5). |
+| Tests pass individually but fail as a suite | Progress state leaking between tests — confirm you see the `[resetRegistration] … clean slate` line at the start of the run. |
+| Scenario AU skips to the End Slide | The registration reset didn't run (missing `MOODLE_BOT_USER_ID` / `MOODLE_RESET_WS_TOKEN`, or you're running via the VS Code extension, which skips `globalSetup`). |
+| Scenario test hangs at "never Ready" | Usually the range backend, not your change. Retry; check RangeOS is up. |
+| Wrong course / weird failures everywhere | `MOODLE_ACTIVITY_ID` points at the wrong activity. Confirm it against `mod/cmi5/view.php?id=<id>`. |
+| `npm run e2e` warns "Activity id changed" | The upsert created a NEW activity (new project, or the `courseId` IRI changed). Set `MOODLE_ACTIVITY_ID` to the cmid it printed. |
+
+### Setting up the reset token (one time)
+
+`mod_cmi5_reset_registration_state` can't be added to the built-in "RapidCMI5
+Integration" service through the Moodle UI. Create a **custom** external
+service, add `mod_cmi5_reset_registration_state` (plus
+`core_user_get_users_by_field` if you want the userid auto-lookup), mint a token
+on it, and set `MOODLE_RESET_WS_TOKEN`. It falls back to `MOODLE_WS_TOKEN` if
+both functions ever live on one service.
+
+---
+
+## 7. Todo / upcoming
 
 | Todo | Notes |
 | --- | --- |
-| LMS statement tests | currently none |
-| Resume lesson tests | currently none |
-| More detailed scenario checks (i.e. autograder etc.) | currently none |
-| Quiz runner scenario test | currently none |
-| Tests to check scores in Moodle and gradebook | currently none |
-| Add upsert support for existing Moodle course update | important since each run needs to be clean |
+| LMS statement tests | none yet |
+| Resume lesson tests | none yet |
+| More detailed scenario checks (autograder etc.) | none yet |
+| Quiz runner scenario test | none yet |
+| Tests to check scores in Moodle and the gradebook | none yet |
+| Run the suite in CI | currently local / on-demand only |

--- a/apps/cc-cmi5-moodle-e2e/playwright.config.ts
+++ b/apps/cc-cmi5-moodle-e2e/playwright.config.ts
@@ -16,7 +16,7 @@ loadEnv({ path: join(workspaceRoot, '.env') });
  * point Playwright at it via `MOODLE_BASE_URL` and authenticate as the
  * e2e bot account inside the browser session.
  *
- * See docs/moodle-player-e2e-strategy.md.
+ * See apps/cc-cmi5-moodle-e2e/README.md.
  */
 const baseURL =
   process.env['MOODLE_BASE_URL'] ||
@@ -43,7 +43,7 @@ export default defineConfig({
   // path — present on main, unrelated to these tests). That blanks the
   // player iframe and fails whatever test ran during that launch. Retry so a
   // transient crash re-launches instead of red-flagging the suite. See the
-  // known-issue note in docs/moodle-player-e2e-strategy.md.
+  // known-issue note in apps/cc-cmi5-moodle-e2e/README.md.
   retries: 2,
   use: {
     baseURL,

--- a/apps/cc-cmi5-moodle-e2e/project.json
+++ b/apps/cc-cmi5-moodle-e2e/project.json
@@ -28,9 +28,13 @@
           "project": ["chromium"],
           "ui": true
         },
-        "launch": {
+        "content": {
           "project": ["chromium"],
-          "grep": "@launch"
+          "grep": "@content"
+        },
+        "quizzes": {
+          "project": ["chromium"],
+          "grep": "@quizzes"
         },
         "scenario": {
           "project": ["chromium"],

--- a/apps/cc-cmi5-moodle-e2e/scripts/e2e-run.js
+++ b/apps/cc-cmi5-moodle-e2e/scripts/e2e-run.js
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+/**
+ * One command for the whole Moodle e2e developer loop.
+ *
+ * Walks you through the three things that have to happen in order, asking
+ * before each so you can skip the expensive ones:
+ *
+ *   1. Build the player       (default NO  — slow, and only needed if you
+ *                              changed the player)
+ *   2. Upload the course zip  (default NO  — only needed if the player or the
+ *                              course content changed)
+ *   3. Run the Playwright tests (default YES)
+ *
+ * The defaults describe "loop A" from the README — verifying the suite still
+ * works, where nothing needs rebuilding. Answering yes to 1 and 2 gives you
+ * "loop B", the develop-a-player-change loop.
+ *
+ * Why this exists: the tests hit REMOTE Moodle. Nothing in the test run picks
+ * up local player changes, so editing the player and running the tests without
+ * a build+upload silently passes against the OLD player. This script keeps the
+ * ordering honest and warns when you're about to do exactly that.
+ *
+ * Step 2 (export the course from the editor UI) can't be automated — the zip
+ * has to bundle the freshly-built player WITH the course content, and that
+ * export lives in the editor. The script pauses and tells you to do it.
+ *
+ * Usage:
+ *   npm run e2e                      # interactive prompts
+ *   npm run e2e -- --build           # force build (no prompt)
+ *   npm run e2e -- --upload          # force upload (no prompt)
+ *   npm run e2e -- --all             # build + upload + test, no prompts
+ *   npm run e2e -- --no-test         # build/upload only
+ *   npm run e2e -- --zip <path>      # explicit zip (else newest in Downloads)
+ *   npm run e2e -- --config scenario # any e2e configuration (default chromium)
+ *   npm run e2e -- --yes             # accept all defaults, no prompts
+ */
+
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const readline = require('node:readline');
+const { spawn } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '../../..');
+
+// ---------------------------------------------------------------- args ----
+
+const argv = process.argv.slice(2);
+const has = (flag) => argv.includes(`--${flag}`);
+const val = (name, fallback) => {
+  const i = argv.indexOf(`--${name}`);
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+
+const opts = {
+  all: has('all'),
+  yes: has('yes') || has('all'),
+  build: has('build') || has('all'),
+  upload: has('upload') || has('all'),
+  noTest: has('no-test'),
+  zip: val('zip'),
+  config: val('config', 'chromium'),
+};
+
+// ------------------------------------------------------------- helpers ----
+
+const c = {
+  b: (s) => `\x1b[1m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+};
+
+function heading(step, total, title) {
+  console.log('');
+  console.log(c.b(`── ${step}/${total}  ${title} ` + '─'.repeat(Math.max(0, 46 - title.length))));
+}
+
+let rl;
+function prompt(question) {
+  if (!rl) {
+    rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  }
+  return new Promise((resolve) => rl.question(question, resolve));
+}
+
+/** Yes/no with an explicit default. Non-interactive (--yes) takes the default. */
+async function confirm(question, defaultYes) {
+  const suffix = defaultYes ? c.dim('[Y/n]') : c.dim('[y/N]');
+  if (opts.yes) {
+    console.log(`${question} ${suffix} ${c.dim(defaultYes ? '→ yes' : '→ no')}`);
+    return defaultYes;
+  }
+  const answer = (await prompt(`${question} ${suffix} `)).trim().toLowerCase();
+  if (!answer) return defaultYes;
+  return answer === 'y' || answer === 'yes';
+}
+
+/**
+ * Run a command. Rejects on non-zero exit.
+ *
+ * With `capture`, stdout is teed — still streamed to the terminal so you see
+ * progress live, and also returned so we can read values out of it (the upload
+ * script prints the resulting cmid, which we need to detect an id change).
+ */
+function run(cmd, args, label, capture = false) {
+  return new Promise((resolve, reject) => {
+    console.log(c.dim(`$ ${cmd} ${args.join(' ')}`));
+    // shell:true so `npx`/`npm` resolve through .cmd shims on Windows.
+    const child = spawn(cmd, args, {
+      cwd: repoRoot,
+      stdio: capture ? ['inherit', 'pipe', 'inherit'] : 'inherit',
+      shell: true,
+    });
+    let out = '';
+    if (capture && child.stdout) {
+      child.stdout.on('data', (chunk) => {
+        out += chunk;
+        process.stdout.write(chunk);
+      });
+    }
+    child.on('error', reject);
+    child.on('close', (code) =>
+      code === 0
+        ? resolve(out)
+        : reject(new Error(`${label} failed (exit ${code})`)),
+    );
+  });
+}
+
+/**
+ * Clear the bot's cmi5 progress for an activity, via the same Moodle WS the
+ * Playwright globalSetup uses (mod_cmi5_reset_registration_state).
+ *
+ * Why here as well: globalSetup only runs when the SUITE runs, and in this
+ * script's ordering that is always AFTER the upload. Clearing here means an
+ * upload-only run (--no-test) still leaves Moodle clean, and that the clear
+ * targets the cmid we actually just deployed.
+ *
+ * Implemented with plain fetch rather than importing src/lms/resetRegistration.ts
+ * — that is TypeScript, which this plain-Node script can't require.
+ *
+ * Best-effort: failures are reported, not fatal, since globalSetup retries.
+ */
+async function resetProgress(cmid) {
+  const base = (process.env.MOODLE_BASE_URL || '').replace(/\/$/, '') ||
+    'https://moodle5.develop-cp.rangeos.engineering';
+  const token =
+    process.env.MOODLE_RESET_WS_TOKEN || process.env.MOODLE_WS_TOKEN;
+  const userid = process.env.MOODLE_BOT_USER_ID;
+
+  if (!token || !userid) {
+    console.log(
+      c.yellow(
+        '  ⚠  Skipping progress clear — need MOODLE_BOT_USER_ID and ' +
+          'MOODLE_RESET_WS_TOKEN.',
+      ),
+    );
+    return;
+  }
+
+  const body = new URLSearchParams({
+    wstoken: token,
+    wsfunction: 'mod_cmi5_reset_registration_state',
+    moodlewsrestformat: 'json',
+    cmid: String(cmid),
+    userid: String(userid),
+  });
+
+  try {
+    const res = await fetch(`${base}/webservice/rest/server.php`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    const data = await res.json().catch(() => ({}));
+    // Moodle returns HTTP 200 even on failure; the error is in the body.
+    if (data && (data.exception || data.errorcode)) {
+      // "registrationnotfound" = the bot never launched this activity, so
+      // there is nothing to clear. That IS a clean slate.
+      if (/registrationnotfound/i.test(String(data.errorcode))) {
+        console.log(
+          c.dim(`  · no prior progress on cmid=${cmid} — already clean`),
+        );
+        return;
+      }
+      throw new Error(`${data.errorcode || 'error'} — ${data.message || ''}`);
+    }
+    console.log(
+      c.green(`  ✓ Cleared progress: cmid=${cmid} userid=${userid}`),
+    );
+  } catch (err) {
+    console.log(c.yellow(`  ⚠  Could not clear progress (${err.message}).`));
+    console.log(c.dim('     The test run will retry it in globalSetup.'));
+  }
+}
+
+/** Newest *.zip in Downloads, preferring names that look like a course export. */
+function findNewestZip() {
+  const dir = path.join(os.homedir(), 'Downloads');
+  if (!fs.existsSync(dir)) return null;
+  const zips = fs
+    .readdirSync(dir)
+    .filter((f) => f.toLowerCase().endsWith('.zip'))
+    .map((f) => {
+      const full = path.join(dir, f);
+      return { full, name: f, mtime: fs.statSync(full).mtimeMs };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+  if (!zips.length) return null;
+  // Prefer something that smells like the e2e course export, else newest.
+  return (zips.find((z) => /e2e/i.test(z.name)) || zips[0]).full;
+}
+
+function ago(ms) {
+  const mins = Math.round((Date.now() - ms) / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs} hr ago`;
+  return `${Math.round(hrs / 24)} days ago`;
+}
+
+// ---------------------------------------------------------------- main ----
+
+async function main() {
+  console.log('');
+  console.log(c.b('  Moodle E2E — developer loop'));
+  console.log(
+    c.dim('  The tests run against REMOTE Moodle, so player changes are only'),
+  );
+  console.log(
+    c.dim('  visible after a build + upload. See apps/cc-cmi5-moodle-e2e/README.md'),
+  );
+
+  // ---- 1. build the player ----
+  heading(1, 3, 'Build the player?');
+  console.log(
+    c.dim('  Only needed if you changed the PLAYER. Takes a few minutes.'),
+  );
+  const doBuild =
+    opts.build || (await confirm('  Build the production player?', false));
+
+  if (doBuild) {
+    await run('npm', ['run', 'build:player-for-editor'], 'Player build');
+    console.log(c.green('  ✓ Player built and staged into the editor assets.'));
+  } else {
+    console.log(c.dim('  Skipped.'));
+  }
+
+  // ---- 2. upload the course zip ----
+  heading(2, 3, 'Upload the course to Moodle?');
+  console.log(
+    c.dim('  Needed if the player or the course content changed.'),
+  );
+  if (doBuild) {
+    console.log(
+      c.yellow(
+        '  You just built the player — upload, or the tests use the OLD one.',
+      ),
+    );
+  }
+  const doUpload =
+    opts.upload || (await confirm('  Upload a course zip to Moodle?', doBuild));
+
+  if (doUpload) {
+    if (doBuild) {
+      console.log('');
+      console.log(c.yellow('  ⚠  First export the course from the editor UI.'));
+      console.log(
+        c.dim(
+          '     The zip must bundle the player you just built WITH the course\n' +
+            '     content — only the editor export does that. Building alone is\n' +
+            '     not enough.',
+        ),
+      );
+      if (!opts.yes) await prompt(c.dim('     Press Enter once the export has downloaded… '));
+    }
+
+    let zip = opts.zip;
+    if (!zip) {
+      const guess = findNewestZip();
+      if (guess) {
+        const when = ago(fs.statSync(guess).mtimeMs);
+        console.log('');
+        console.log(`  Newest zip: ${c.cyan(guess)} ${c.dim(`(${when})`)}`);
+        const ok = await confirm('  Use this zip?', true);
+        zip = ok ? guess : (await prompt('  Path to zip: ')).trim().replace(/^["']|["']$/g, '');
+      } else {
+        zip = (await prompt('  Path to zip: ')).trim().replace(/^["']|["']$/g, '');
+      }
+    }
+
+    if (!zip || !fs.existsSync(path.resolve(zip))) {
+      throw new Error(`Zip not found: ${zip || '(none given)'}`);
+    }
+
+    const uploadOut = await run(
+      'node',
+      [path.join(__dirname, 'upload-zip-to-moodle.js'), '--zip', `"${path.resolve(zip)}"`],
+      'Course upload',
+      true, // capture stdout so we can read back the resulting cmid
+    );
+    console.log(c.green('  ✓ Course upserted into Moodle.'));
+
+    // The upsert preserves the cmid, but a NEW project (or a changed courseId
+    // IRI) yields a new one. If that happens, .env.local is now stale and both
+    // the reset below and the tests would target the wrong activity.
+    const deployedCmid = (uploadOut.match(/activity cmid=(\d+)/) || [])[1];
+    const configuredCmid = process.env.MOODLE_ACTIVITY_ID;
+    if (deployedCmid && configuredCmid && deployedCmid !== configuredCmid) {
+      console.log('');
+      console.log(
+        c.red(
+          `  ⚠  Activity id changed: deployed cmid=${deployedCmid}, but ` +
+            `.env.local has MOODLE_ACTIVITY_ID=${configuredCmid}.`,
+        ),
+      );
+      console.log(
+        c.yellow(
+          `     Update .env.local to MOODLE_ACTIVITY_ID=${deployedCmid}, ` +
+            'or the tests will run against the OLD activity.',
+        ),
+      );
+    }
+
+    // Clear the bot's progress NOW, against the cmid we just deployed — the
+    // upsert preserves prior progress, so without this a scenario AU resumes
+    // as already-Satisfied. globalSetup does this too, but only if the suite
+    // runs, and only against the configured id.
+    await resetProgress(deployedCmid || configuredCmid);
+  } else {
+    console.log(c.dim('  Skipped.'));
+    if (doBuild) {
+      console.log(
+        c.red(
+          '  ⚠  You built the player but did NOT upload it. The tests will run\n' +
+            '     against the previously-uploaded player — a pass proves nothing\n' +
+            '     about your change.',
+        ),
+      );
+    }
+  }
+
+  // ---- 3. run the tests ----
+  heading(3, 3, 'Run the tests');
+  if (opts.noTest) {
+    console.log(c.dim('  Skipped (--no-test).'));
+  } else {
+    const doTest = await confirm(
+      `  Run the e2e suite (${c.cyan(opts.config)})?`,
+      true,
+    );
+    if (doTest) {
+      if (rl) rl.close(); // release stdin before Playwright takes over
+      rl = null;
+      await run(
+        'npx',
+        ['nx', 'e2e', 'cc-cmi5-moodle-e2e', `--configuration=${opts.config}`],
+        'Playwright suite',
+      );
+      console.log(c.green('  ✓ Suite finished.'));
+    } else {
+      console.log(c.dim('  Skipped.'));
+    }
+  }
+
+  if (rl) rl.close();
+  console.log('');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    if (rl) rl.close();
+    console.error('');
+    console.error(c.red(`✖ ${err.message}`));
+    process.exit(1);
+  });

--- a/apps/cc-cmi5-moodle-e2e/src/fixtures/moodle-course-fixture.ts
+++ b/apps/cc-cmi5-moodle-e2e/src/fixtures/moodle-course-fixture.ts
@@ -16,7 +16,7 @@ import { moodleEnv } from '../moodle/env';
  *   - Components:Basic     (tabs / accordion / grid / statements)
  *   - Quiz:Basic           (one :::quiz slide)
  * (Individual and Class scenarios can't live in the same cmi5 lesson, hence
- *  the split — see docs/moodle-player-e2e-strategy.md.)
+ *  the split — see apps/cc-cmi5-moodle-e2e/README.md.)
  *
  * A spec declares which AU it exercises via the `auName` option:
  *

--- a/apps/cc-cmi5-moodle-e2e/src/moodle/env.ts
+++ b/apps/cc-cmi5-moodle-e2e/src/moodle/env.ts
@@ -15,7 +15,7 @@ function required(name: string): string {
     throw new Error(
       `Missing required env var ${name}. ` +
         `Set it in a gitignored .env at the repo root or as a CI secret. ` +
-        `See docs/moodle-player-e2e-strategy.md.`,
+        `See apps/cc-cmi5-moodle-e2e/README.md.`,
     );
   }
   return value.trim();
@@ -40,14 +40,16 @@ export const moodleEnv = {
   },
   /**
    * cmi5 activity id — the `id` in `mod/cmi5/view.php?id=<id>`.
-   * Points at the manually-uploaded e2e course (744, in course container 75)
-   * which carries a PRODUCTION player build (with the player-* / directive-*
-   * test-ids; a dev build 404s its vendor.js → blank player). Re-uploading
-   * manually changes this id — override via MOODLE_ACTIVITY_ID in .env.local.
-   * Programmatic update-in-place (phase 3) will keep it stable.
+   * Points at the e2e course activity (in course container 75) which carries a
+   * PRODUCTION player build (with the player-* / directive-* test-ids; a dev
+   * build 404s its vendor.js → blank player).
+   *
+   * `npm run upload:moodle` upserts IN PLACE, so this id is now stable across
+   * re-uploads. Set MOODLE_ACTIVITY_ID in .env.local; the fallback below is
+   * only a last resort and may be stale.
    */
   get activityId(): string {
-    return optional('MOODLE_ACTIVITY_ID', '744');
+    return optional('MOODLE_ACTIVITY_ID', '784');
   },
 
   // --- Moodle web service (course upsert + registration reset) ---

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cmi5-builder": "nx run cmi5-builder:build",
     "cmi5-player": "nx run cc-cmi5-player:build",
     "upload:moodle": "node apps/cc-cmi5-moodle-e2e/scripts/upload-zip-to-moodle.js",
+    "e2e": "node apps/cc-cmi5-moodle-e2e/scripts/e2e-run.js",
     "postinstall": "electron-builder install-app-deps",
     "nxe:build:frontend": "nx build rapid-cmi5-electron-frontend --configuration=production",
     "nxe:build:backend": "nx build rapid-cmi5-electron --configuration=production",


### PR DESCRIPTION
Returning to the Moodle e2e suite after several months: the content lane still passes (17/17 against live Moodle), but the docs had drifted and gave a new dev no easy entry point.

Added `npm run e2e` — a guided loop that asks before each step:

  1/3  Build the player?             [y/N]   default NO
  2/3  Upload the course to Moodle?  [y/N]   defaults YES if you built
  3/3  Run the tests?                [Y/n]   default YES

Three Enters runs the suite; yes to the first two does the full build -> export -> upload -> test loop. It pauses for the editor export, auto-detects the newest zip in Downloads (showing its age), clears the bot's progress against the cmid it just deployed, and warns if that cmid has diverged from MOODLE_ACTIVITY_ID. Flags: --all, --build, --upload, --yes, --config, --zip, --no-test.

The clear previously lived only in Playwright's globalSetup, so it ran after the upsert and not at all on an upload-only run.

Fixes found along the way:

- `launch` run configuration grepped @launch, a tag that exists nowhere, so it silently ran zero tests. Replaced with working `content` and `quizzes` configurations matching the tags the specs actually use.
- Four references to docs/moodle-player-e2e-strategy.md, a file that does not exist in the repo. One was inside the missing-env-var error message, so the most common first failure pointed at nothing. Repointed to the README.
- env.ts defaulted MOODLE_ACTIVITY_ID to a stale 744 (current is 784) and its comment still described the id-churn that the upsert fixed.

README rewritten run-it-first: quick start up top, background below. It now distinguishes the two loops — verifying the suite vs. testing a player change — because nothing in the test run picks up local player edits, so skipping the build+upload passes green against the previously uploaded player.

Also corrects stale details: scenario.spec.ts is scenario-individual.spec.ts, global-setup.ts and resetRegistration.ts were missing from the layout, and §5 still documented the delete-and-recreate flow the upsert replaced.